### PR TITLE
fix: トンマナ統一のため黒背景固定に修正

### DIFF
--- a/client/lib/ui/component/app_theme.dart
+++ b/client/lib/ui/component/app_theme.dart
@@ -1,12 +1,5 @@
 import 'package:flutter/material.dart';
 
-ThemeData getLightTheme() {
-  return ThemeData(
-    useMaterial3: true,
-    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-  );
-}
-
 ThemeData getDarkTheme() {
   return ThemeData(
     useMaterial3: true,

--- a/client/lib/ui/root_app.dart
+++ b/client/lib/ui/root_app.dart
@@ -74,7 +74,6 @@ class _RootAppState extends ConsumerState<RootApp> {
       navigatorObservers: navigatorObservers,
       title: 'カヴィヴァラチャット',
       builder: (_, child) => _wrapByAppBanner(child),
-      theme: getLightTheme(),
       darkTheme: getDarkTheme(),
       themeMode: ThemeMode.dark,
       localizationsDelegates: const [


### PR DESCRIPTION
## Summary
- force the Flutter client to always use the dark theme by setting the MaterialApp theme mode to dark

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da83cdf7b48327863a6ae394040f84