### PR TITLE
feat(client): 猫毛吹き出しに2段目シルエット層を追加

### DIFF
--- a/client/lib/ui/component/cat_fur_bubble_painter.dart
+++ b/client/lib/ui/component/cat_fur_bubble_painter.dart
@@ -30,6 +30,13 @@ class CatFurBubblePainter extends CustomPainter {
   /// 薄いグレーの輪郭として奥行きを与える。
   static const _silhouetteInset = 5.0;
 
+  /// 2段目シルエット層の生え際を、外側ストランドの生え際からどれだけ内側に置くか（px）。
+  /// 1段目シルエットとの余白を視認できるよう `_silhouetteInset` よりだいぶ大きい値
+  /// を取り、より薄いグレーで塗ることで奥行きを強調する。`_backgroundCornerRadius
+  /// + _maxBaseOffset = 14` を超えると同心円コーナーの半径が負になるため、その範囲
+  /// 内に収める。
+  static const double _innerSilhouetteInset = 13;
+
   /// 背景の角丸半径。内側の塗りつぶし矩形と外側の背景矩形で
   /// コーナー中心が同心になるよう、内側半径はここから派生して算出する。
   static const _backgroundCornerRadius = 12.0;
@@ -122,19 +129,23 @@ class CatFurBubblePainter extends CustomPainter {
   ///
   /// この塗りつぶしと内側ストランドが繋がることで、奥側に敷いた薄いグレーの
   /// 一体的なシルエットとして見えるようになる。
-  /// 矩形は背景矩形より `_silhouetteInset - _maxBaseOffset` だけ内側に置き、
-  /// 半径もその分だけ縮めることで、外側背景とコーナー中心が同心になる。
-  void _drawSilhouetteFill(Canvas canvas, Size size, Color color) {
-    const innerRadius =
-        _backgroundCornerRadius - (_silhouetteInset - _maxBaseOffset);
+  /// 矩形は背景矩形より `inset - _maxBaseOffset` だけ内側に置き、半径もその分だけ
+  /// 縮めることで、外側背景とコーナー中心が同心になる。
+  void _drawSilhouetteFill(
+    Canvas canvas,
+    Size size,
+    Color color,
+    double inset,
+  ) {
+    final innerRadius = _backgroundCornerRadius - (inset - _maxBaseOffset);
     final rect = RRect.fromRectAndRadius(
       Rect.fromLTRB(
-        _silhouetteInset,
-        _silhouetteInset,
-        size.width - _silhouetteInset,
-        size.height - _silhouetteInset,
+        inset,
+        inset,
+        size.width - inset,
+        size.height - inset,
       ),
-      const Radius.circular(innerRadius),
+      Radius.circular(innerRadius),
     );
     canvas.drawRRect(
       rect,
@@ -175,7 +186,7 @@ class CatFurBubblePainter extends CustomPainter {
       // 枠線・塗りつぶしともに薄いグレーで揃え、奥側に控えめなシルエットとして敷く。
       // 文字が乗る中央領域も同色で塗り、内側ストランドと一体のシルエットに見せる。
       final silhouetteColor = Colors.grey.shade200;
-      _drawSilhouetteFill(canvas, size, silhouetteColor);
+      _drawSilhouetteFill(canvas, size, silhouetteColor, _silhouetteInset);
       _drawAlignedInnerStrandLayer(
         canvas,
         size,
@@ -184,6 +195,31 @@ class CatFurBubblePainter extends CustomPainter {
         strokeColor: silhouetteColor,
         fillColor: silhouetteColor,
       );
+
+      // 2段目シルエット：1段目の内側にさらに重ね、より薄いグレーで塗る。
+      // 内側ストランドと塗りつぶしを連動させて、1段目と同様に一体のシルエット
+      // として見せる。1段目より敷ける余白が狭くなるため、ここで改めて
+      // フィット判定を行う。
+      final innerSilhouetteFits =
+          size.width > 2 * (_cornerMargin + _innerSilhouetteInset) &&
+          size.height > 2 * (_cornerMargin + _innerSilhouetteInset);
+      if (innerSilhouetteFits) {
+        final innerSilhouetteColor = Colors.grey.shade100;
+        _drawSilhouetteFill(
+          canvas,
+          size,
+          innerSilhouetteColor,
+          _innerSilhouetteInset,
+        );
+        _drawAlignedInnerStrandLayer(
+          canvas,
+          size,
+          outerSeed: seed,
+          inset: _innerSilhouetteInset,
+          strokeColor: innerSilhouetteColor,
+          fillColor: innerSilhouetteColor,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## 概要

PR #332 で追加した猫毛吹き出しのシルエット層に、もう一段奥のシルエット層を重ねて奥行きをさらに強調する。

- 1段目シルエット (`_silhouetteInset = 5.0`) の内側に、2段目シルエット (`_innerSilhouetteInset = 13`) を重ねる
- 2段目はより薄い `Colors.grey.shade100` を用い、内側ストランドと塗りつぶしを連動させて1段目と同じく一体のシルエットとして見せる
- `_drawSilhouetteFill` をリファクタし、`inset` を引数として受け取れるよう汎用化（同心コーナー算出も `inset` ベースに変更）
- 2段目はサイズが小さい場合に描画余白を確保できないため、`innerSilhouetteFits` で個別にフィット判定を行う

## Related Issue

- なし

## レビューで見て欲しいポイント

- *（作業指示者に記載してもらう）*

## 追加・修正ファイル

- `client/lib/ui/component/cat_fur_bubble_painter.dart`
  - `_innerSilhouetteInset` 定数を追加（同心コーナー半径が負にならない上限内に設定）
  - `_drawSilhouetteFill` に `inset` 引数を追加し、複数のシルエット層で再利用できるよう一般化
  - `paint` 内で2段目シルエットを描画（フィット判定 → 塗りつぶし → 整列内側ストランド の順）

## Screenshots & Demo

- *（作業指示者に記載してもらう）*

🤖 Generated with [Claude Code](https://claude.com/claude-code)