### PR TITLE
feat(client): 猫毛吹き出しをダークモードに対応

### DIFF
--- a/client/lib/ui/component/cat_fur_bubble_painter.dart
+++ b/client/lib/ui/component/cat_fur_bubble_painter.dart
@@ -7,8 +7,11 @@ import 'package:flutter/material.dart';
 /// 各辺と四隅の輪郭に沿って2次ベジェ曲線で構成した毛束を敷き詰め、
 /// [windAnimation] が指定されている場合は毛先を風揺れさせる。
 class CatFurBubblePainter extends CustomPainter {
-  CatFurBubblePainter({required this.seed, this.windAnimation})
-    : super(repaint: windAnimation);
+  CatFurBubblePainter({
+    required this.seed,
+    required this.brightness,
+    this.windAnimation,
+  }) : super(repaint: windAnimation);
 
   /// 描画される毛先が背景矩形の外側に突き出しうる最大距離（px）。
   /// 親ウィジェットに余白として確保してもらうための公開定数。
@@ -90,9 +93,49 @@ class CatFurBubblePainter extends CustomPainter {
 
   final int seed;
 
+  /// 描画パレットを切り替えるためのテーマ輝度。
+  /// ライト/ダークそれぞれで、毛束・シルエット・シャドーの色を入れ替える。
+  final Brightness brightness;
+
   /// 風のアニメーション。0..1 で1サイクルとして扱う。
   /// null の場合は揺れずに静止状態で描画する。
   final Animation<double>? windAnimation;
+
+  // ===== 描画パレット =====
+  //
+  // ライトモードでは「外側=白」「リング=やや暗いグレー」「中心=その間のグレー」
+  // 「シャドー=最も暗い」の順で奥行きを表現している。ダークモードでも同じ相対
+  // 順序（外側が最も明るく、リングが最も暗いシルエット、中心はその間、シャドーは
+  // リングよりさらに暗い）を保ち、色だけを暗い側にシフトする。
+
+  static const _darkBubbleFillColor = Color(0xFF2C2C2C);
+  static const _darkSilhouetteCenterColor = Color(0xFF252525);
+  static const _darkSilhouetteRingColor = Color(0xFF1C1C1C);
+  static const _darkShadowColor = Color(0xFF0F0F0F);
+
+  bool get _isDark => brightness == Brightness.dark;
+
+  /// 背景矩形と外側ストランドの塗りつぶし色。
+  Color get _bubbleFillColor => _isDark ? _darkBubbleFillColor : Colors.white;
+
+  /// 外側ストランドの輪郭線色。
+  /// ダークモードでは明るい線が浮いて見えるため、地のダーク面とほぼ同じ濃度の
+  /// グレーまで落として、毛先の形だけが微かに見える程度に沈ませる。
+  Color get _outerStrokeColor => _isDark
+      ? Colors.grey.shade900.withAlpha(180)
+      : Colors.grey.shade600.withAlpha(180);
+
+  /// 1段目シルエット層の色（外側より一段奥に見える「影リング」）。
+  Color get _outerSilhouetteColor =>
+      _isDark ? _darkSilhouetteRingColor : Colors.grey.shade200;
+
+  /// 2段目シルエット層の色（文字が乗る中央領域）。
+  Color get _innerSilhouetteColor =>
+      _isDark ? _darkSilhouetteCenterColor : Colors.grey.shade100;
+
+  /// 下側に落ちる立体感のためのシャドー帯色。
+  Color get _shadowOverlayColor =>
+      _isDark ? _darkShadowColor : Colors.grey.shade300;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -103,6 +146,7 @@ class CatFurBubblePainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant CatFurBubblePainter oldDelegate) {
     return oldDelegate.seed != seed ||
+        oldDelegate.brightness != brightness ||
         oldDelegate.windAnimation != windAnimation;
   }
 
@@ -120,7 +164,7 @@ class CatFurBubblePainter extends CustomPainter {
     canvas.drawRRect(
       bgRect,
       Paint()
-        ..color = Colors.white
+        ..color = _bubbleFillColor
         ..style = PaintingStyle.fill,
     );
   }
@@ -167,8 +211,8 @@ class CatFurBubblePainter extends CustomPainter {
       size,
       layerSeed: seed,
       inset: 0,
-      strokeColor: Colors.grey.shade600.withAlpha(180),
-      fillColor: Colors.white,
+      strokeColor: _outerStrokeColor,
+      fillColor: _bubbleFillColor,
     );
 
     // 内側ストランドが少しでも描かれるのは、辺の中央部に余白を含めた長さが
@@ -185,7 +229,7 @@ class CatFurBubblePainter extends CustomPainter {
 
       // 枠線・塗りつぶしともに薄いグレーで揃え、奥側に控えめなシルエットとして敷く。
       // 文字が乗る中央領域も同色で塗り、内側ストランドと一体のシルエットに見せる。
-      final silhouetteColor = Colors.grey.shade200;
+      final silhouetteColor = _outerSilhouetteColor;
       _drawSilhouetteFill(canvas, size, silhouetteColor, _silhouetteInset);
       _drawAlignedInnerStrandLayer(
         canvas,
@@ -204,7 +248,7 @@ class CatFurBubblePainter extends CustomPainter {
           size.width > 2 * (_cornerMargin + _innerSilhouetteInset) &&
           size.height > 2 * (_cornerMargin + _innerSilhouetteInset);
       if (innerSilhouetteFits) {
-        final innerSilhouetteColor = Colors.grey.shade100;
+        final innerSilhouetteColor = _innerSilhouetteColor;
         _drawSilhouetteFill(
           canvas,
           size,
@@ -244,9 +288,8 @@ class CatFurBubblePainter extends CustomPainter {
   /// 矩形を 2 枚（x の境界はキャンバス中央）並べて構成しているが、上端の
   /// 段差はシルエット内側に隠れて見えない。
   ///
-  /// 影色 `Colors.grey.shade300` は、外側ストランドの枠線色
-  /// （`shade600` の alpha 180、白との実効ブレンドで `shade500` 相当の輝度）
-  /// よりは薄く、シルエット（`shade200`）よりは濃くなるよう選定している。
+  /// 影色は外側ストランドの枠線色よりは薄く、シルエットよりは濃くなるよう
+  /// パレット側で選定している（ライト/ダークそれぞれで対応する濃度を持つ）。
   void _drawShadowOverlay(Canvas canvas, Size size) {
     // 毛先がキャンバス外にも伸びる分、外周方向には [maxOuterExtent] ぶん
     // 余裕を持たせる。上端は左半分が下 1/3 (y >= 2H/3)、右半分が下 2/3
@@ -268,7 +311,7 @@ class CatFurBubblePainter extends CustomPainter {
           size.height + maxOuterExtent,
         ),
       );
-    final shadowColor = Colors.grey.shade300;
+    final shadowColor = _shadowOverlayColor;
 
     canvas
       ..save()
@@ -284,7 +327,7 @@ class CatFurBubblePainter extends CustomPainter {
       size,
       layerSeed: seed,
       inset: 0,
-      strokeColor: Colors.grey.shade600.withAlpha(180),
+      strokeColor: _outerStrokeColor,
       fillColor: shadowColor,
     );
     canvas.restore();

--- a/client/lib/ui/component/cat_fur_bubble_painter.dart
+++ b/client/lib/ui/component/cat_fur_bubble_painter.dart
@@ -17,6 +17,14 @@ class CatFurBubblePainter extends CustomPainter {
   /// 親ウィジェットに余白として確保してもらうための公開定数。
   static const maxOuterExtent = 10.0;
 
+  /// 猫毛吹き出しの中央領域に乗せる文字色として推奨される色。
+  /// 中央領域（2段目シルエット）の濃度に対して十分なコントラストを確保する。
+  static Color recommendedForegroundColor(Brightness brightness) {
+    return brightness == Brightness.dark
+        ? Colors.grey.shade100
+        : Colors.grey.shade800;
+  }
+
   // ===== ジオメトリ定数 =====
 
   /// 角丸部分を避けるマージン

--- a/client/lib/ui/component/chat_bubble_design_extension.dart
+++ b/client/lib/ui/component/chat_bubble_design_extension.dart
@@ -171,6 +171,7 @@ class _CatFurBubbleState extends State<_CatFurBubble>
     return CustomPaint(
       painter: CatFurBubblePainter(
         seed: widget.seed,
+        brightness: Theme.of(context).brightness,
         windAnimation: _windController,
       ),
       child: Container(

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -9,6 +9,7 @@ import 'package:house_worker/data/repository/chat_bubble_design_repository.dart'
 import 'package:house_worker/data/repository/skip_clear_chat_confirmation_repository.dart';
 import 'package:house_worker/data/service/cavivara_directory_service.dart';
 import 'package:house_worker/ui/component/app_drawer.dart';
+import 'package:house_worker/ui/component/cat_fur_bubble_painter.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/component/chat_bubble_design_extension.dart';
 import 'package:house_worker/ui/component/clear_chat_confirmation_dialog.dart';
@@ -764,7 +765,9 @@ class _UserChatBubble extends ConsumerWidget {
     final design = designAsync.value ?? ChatBubbleDesign.corporateStandard;
 
     final textColor = design == ChatBubbleDesign.catFur
-        ? Colors.grey.shade800
+        ? CatFurBubblePainter.recommendedForegroundColor(
+            Theme.of(context).brightness,
+          )
         : Theme.of(context).colorScheme.onPrimaryContainer;
     final bodyText = Text(
       message.content,
@@ -829,7 +832,9 @@ class _AiChatBubble extends ConsumerWidget {
     final designAsync = ref.watch(chatBubbleDesignRepositoryProvider);
     final design = designAsync.value ?? ChatBubbleDesign.corporateStandard;
     final textColor = design == ChatBubbleDesign.catFur
-        ? Colors.grey.shade800
+        ? CatFurBubblePainter.recommendedForegroundColor(
+            Theme.of(context).brightness,
+          )
         : Theme.of(context).colorScheme.onSurface;
     final indicatorColor = Theme.of(context).colorScheme.primary;
 

--- a/client/test/ui/component/chat_bubble_design_extension_test.dart
+++ b/client/test/ui/component/chat_bubble_design_extension_test.dart
@@ -186,6 +186,65 @@ void main() {
     );
 
     testWidgets(
+      'catFur design propagates Brightness.light to CatFurBubblePainter '
+      'under default (light) MaterialApp theme',
+      (WidgetTester tester) async {
+        const design = ChatBubbleDesign.catFur;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return design.buildBubble(
+                    context: context,
+                    messageType: MessageType.user,
+                    backgroundColor: Colors.blue,
+                    child: const Text('User message'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        final painter = _findCatFurPainter(tester);
+        expect(painter.brightness, Brightness.light);
+      },
+    );
+
+    testWidgets(
+      'catFur design propagates Brightness.dark to CatFurBubblePainter '
+      'under dark MaterialApp theme',
+      (WidgetTester tester) async {
+        const design = ChatBubbleDesign.catFur;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.light(),
+            darkTheme: ThemeData.dark(),
+            themeMode: ThemeMode.dark,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return design.buildBubble(
+                    context: context,
+                    messageType: MessageType.user,
+                    backgroundColor: Colors.blue,
+                    child: const Text('User message'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        final painter = _findCatFurPainter(tester);
+        expect(painter.brightness, Brightness.dark);
+      },
+    );
+
+    testWidgets(
       'nextGeneration design creates bubble with uniform radius '
       'for system message',
       (WidgetTester tester) async {
@@ -238,4 +297,31 @@ void main() {
       expect(design.displayName, '猫毛様式');
     });
   });
+
+  group('CatFurBubblePainter.recommendedForegroundColor', () {
+    test('returns grey.shade800 for light brightness', () {
+      expect(
+        CatFurBubblePainter.recommendedForegroundColor(Brightness.light),
+        Colors.grey.shade800,
+      );
+    });
+
+    test('returns grey.shade100 for dark brightness', () {
+      expect(
+        CatFurBubblePainter.recommendedForegroundColor(Brightness.dark),
+        Colors.grey.shade100,
+      );
+    });
+  });
+}
+
+/// テスト対象ウィジェットツリーから [CatFurBubblePainter] を 1 つ取り出す。
+CatFurBubblePainter _findCatFurPainter(WidgetTester tester) {
+  final paint = tester.widget<CustomPaint>(
+    find.byWidgetPredicate(
+      (widget) =>
+          widget is CustomPaint && widget.painter is CatFurBubblePainter,
+    ),
+  );
+  return paint.painter! as CatFurBubblePainter;
 }


### PR DESCRIPTION
## 概要

猫毛様式の吹き出し（`ChatBubbleDesign.catFur`）がライトモード向けの色しか持っておらず、ダークモードでも白い吹き出しと暗いストロークで描画されていた。これをテーマ輝度に追従するように対応した。

- `CatFurBubblePainter` に `brightness` パラメータを追加し、背景・外側ストランド・1段目/2段目シルエット・落ち影・ストロークの各色をライト/ダーク両用のパレットに切り替え。ライトモードの「外側が最も明るく、リングが最も暗く、中心はその間、シャドーはさらに暗い」という相対順序はダーク側でも維持。
- `_CatFurBubble` から `Theme.of(context).brightness` を painter に渡し、テーマ変更時には `shouldRepaint` で再描画されるように更新。
- ダークモードでストロークが浮いて見えたため、ストローク色を `shade900`(α180) まで下げて地のダーク面に沈めた。
- 猫毛様式時の本文文字色が `home_screen.dart` 側で `Colors.grey.shade800` 固定になっており、ダーク時に暗い中央領域へ暗い文字が乗って読めなくなる問題があったため、`CatFurBubblePainter.recommendedForegroundColor(Brightness)` を新設して両モードでコントラストを確保。

## Related Issue

- 対応する Issue なし

## レビューで見て欲しいポイント

<!-- 例）〇〇メソッドの実行フローが仕様通りになっているか確認お願いします -->
（作業指示者にて記載をお願いします）

## 追加・修正ファイル

- `client/lib/ui/component/cat_fur_bubble_painter.dart`
  - `brightness` パラメータを追加し、輝度に応じた描画パレット（`_bubbleFillColor` / `_outerStrokeColor` / `_outerSilhouetteColor` / `_innerSilhouetteColor` / `_shadowOverlayColor`）を導入
  - `shouldRepaint` の判定に `brightness` を追加
  - 文字色用ヘルパー `recommendedForegroundColor(Brightness)` を追加
- `client/lib/ui/component/chat_bubble_design_extension.dart`
  - `_CatFurBubble.build` で `Theme.of(context).brightness` を painter に渡すよう変更
- `client/lib/ui/feature/home/home_screen.dart`
  - ユーザー／AI 両方の吹き出しで、猫毛様式時の本文文字色を `recommendedForegroundColor` 経由でテーマ輝度に追従させるよう変更

## Screenshots & Demo

<!-- ライトモード／ダークモードでの吹き出し見た目を添付してください -->
（作業指示者にて記載をお願いします）

🤖 Generated with [Claude Code](https://claude.com/claude-code)