### PR TITLE
feat(client): カヴィヴァラ登場演出を統一しトーク画面の入場アニメーションを調整

### DIFF
--- a/client/lib/ui/component/cavivara_entrance_animation.dart
+++ b/client/lib/ui/component/cavivara_entrance_animation.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/animation.dart';
+
+/// カヴィヴァラさんの登場演出で共有するアニメーション定義。
+///
+/// 業績画面の肖像画やトーク画面の入場など、カヴィヴァラさんが画面に
+/// 現れる際の演出で、統一感を出すために時間とカーブを共通化する。
+abstract final class CavivaraEntranceAnimation {
+  /// 登場演出にかける時間。
+  static const duration = Duration(milliseconds: 700);
+
+  /// 登場演出のアニメーションカーブ。少し行き過ぎてから戻ることで、
+  /// ぴょこっと飛び出すような印象を与える。
+  static const Curve curve = Curves.easeOutBack;
+}

--- a/client/lib/ui/component/cavivara_portrait.dart
+++ b/client/lib/ui/component/cavivara_portrait.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
+import 'package:house_worker/ui/component/cavivara_entrance_animation.dart';
 
 /// カヴィヴァラさんの肖像画を、美術館の額装のような額縁付きで表示するウィジェット。
 ///
@@ -157,12 +158,13 @@ class CavivaraPortrait extends StatelessWidget {
     // 表示時に、拡大しながらふわっとフェードインさせる
     return TweenAnimationBuilder<double>(
       tween: Tween(begin: 0, end: 1),
-      duration: const Duration(milliseconds: 1200),
-      curve: Curves.easeOutCubic,
+      duration: CavivaraEntranceAnimation.duration,
+      curve: CavivaraEntranceAnimation.curve,
       child: centeredPortrait,
       builder: (context, value, child) {
         return Opacity(
-          opacity: value,
+          // easeOutBack は終盤で 1.0 を超えるため、不透明度は範囲内に収める
+          opacity: value.clamp(0.0, 1.0),
           child: Transform.scale(
             scale: 0.7 + 0.3 * value,
             child: child,

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -36,8 +36,8 @@ class HomeScreen extends ConsumerStatefulWidget {
 
 class _HomeScreenState extends ConsumerState<HomeScreen>
     with SingleTickerProviderStateMixin {
-  /// 画面表示時に内容がふわっと浮き出る入場アニメーションにかける時間。
-  static const _entranceDuration = Duration(milliseconds: 1000);
+  /// 画面表示時に内容が下からぬるっと浮き上がる入場アニメーションにかける時間。
+  static const _entranceDuration = Duration(milliseconds: 700);
 
   final TextEditingController _messageController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
@@ -57,17 +57,17 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     _messageController.addListener(_onMessageChanged);
     _messageFocusNode.addListener(_onFocusChanged);
 
-    // 画面表示時に内容を下からふわっと浮き出させる。
+    // 画面表示時に内容を下からぬるっと浮き上がらせる。
     _entranceController = AnimationController(
       vsync: this,
       duration: _entranceDuration,
     );
     _entranceFade = CurvedAnimation(
       parent: _entranceController,
-      curve: Curves.easeOut,
+      curve: Curves.easeOutBack,
     );
     _entranceSlide = Tween<Offset>(
-      begin: const Offset(0, 0.04),
+      begin: const Offset(0, 0.18),
       end: Offset.zero,
     ).animate(_entranceFade);
     _entranceController.forward();
@@ -203,7 +203,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       body: body,
     );
 
-    // タイトルバーを含む画面全体を、下からふわっと浮き出させる。
+    // タイトルバーを含む画面全体を、下からぬるっと浮き上がらせる。
     return FadeTransition(
       opacity: _entranceFade,
       child: SlideTransition(
@@ -373,7 +373,7 @@ class _ChatMessageListState extends ConsumerState<_ChatMessageList> {
     widget.controller.animateTo(
       widget.controller.position.maxScrollExtent,
       duration: const Duration(milliseconds: 300),
-      curve: Curves.easeOut,
+      curve: Curves.easeOutBack,
     );
   }
 
@@ -618,7 +618,7 @@ class _ChatSuggestionsState extends State<_ChatSuggestions>
     );
     _fadeAnimation = CurvedAnimation(
       parent: _animationController,
-      curve: Curves.easeOut,
+      curve: Curves.easeOutBack,
     );
 
     // 表示されたら即座にアニメーション開始

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -34,7 +34,11 @@ class HomeScreen extends ConsumerStatefulWidget {
   ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends ConsumerState<HomeScreen> {
+class _HomeScreenState extends ConsumerState<HomeScreen>
+    with SingleTickerProviderStateMixin {
+  /// 画面表示時に内容がふわっと浮き出る入場アニメーションにかける時間。
+  static const _entranceDuration = Duration(milliseconds: 1000);
+
   final TextEditingController _messageController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
   final FocusNode _messageFocusNode = FocusNode();
@@ -42,12 +46,31 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   bool _shouldShowSuggestions = false;
   Timer? _suggestionTimer;
 
+  late final AnimationController _entranceController;
+  late final Animation<double> _entranceFade;
+  late final Animation<Offset> _entranceSlide;
+
   @override
   void initState() {
     super.initState();
 
     _messageController.addListener(_onMessageChanged);
     _messageFocusNode.addListener(_onFocusChanged);
+
+    // 画面表示時に内容を下からふわっと浮き出させる。
+    _entranceController = AnimationController(
+      vsync: this,
+      duration: _entranceDuration,
+    );
+    _entranceFade = CurvedAnimation(
+      parent: _entranceController,
+      curve: Curves.easeOut,
+    );
+    _entranceSlide = Tween<Offset>(
+      begin: const Offset(0, 0.04),
+      end: Offset.zero,
+    ).animate(_entranceFade);
+    _entranceController.forward();
 
     // ビルド完了後にテキストフィールドにフォーカスしてキーボードを表示
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -95,6 +118,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   @override
   void dispose() {
+    _entranceController.dispose();
     _suggestionTimer?.cancel();
     _messageController
       ..removeListener(_onMessageChanged)
@@ -155,7 +179,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ],
     );
 
-    return Scaffold(
+    final scaffold = Scaffold(
       appBar: AppBar(
         title: title,
         actions: [clearButton],
@@ -177,6 +201,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         },
       ),
       body: body,
+    );
+
+    // タイトルバーを含む画面全体を、下からふわっと浮き出させる。
+    return FadeTransition(
+      opacity: _entranceFade,
+      child: SlideTransition(
+        position: _entranceSlide,
+        child: scaffold,
+      ),
     );
   }
 


### PR DESCRIPTION
## 概要

カヴィヴァラさんの「登場演出」を統一し、より弾むようなアニメーションに調整しました。

- トーク画面（ホーム画面）の入場アニメーションを、下からぬるっと浮き上がる動きに変更しました。カーブを `easeOutBack` にし、スライド量と表示時間を見直しています。
- 業績画面の額縁付き肖像画の表示アニメーションも同じ演出に揃え、定義を共通化しました。
- 登場演出で共有するアニメーションの時間・カーブを `CavivaraEntranceAnimation` として定義し、各画面から参照するようにしました。

## Related Issue

- #999 Issue <!-- TODO: 対応する Issue 番号に差し替えてください -->

## レビューで見て欲しいポイント

<!-- TODO: 作業指示者にて記載してください（例：登場演出のカーブ・速度感が意図通りか、額縁とトーク画面で統一感が出ているか など） -->

## 追加・修正ファイル

- /client/lib/ui/component/cavivara_entrance_animation.dart
  - カヴィヴァラ登場演出のアニメーション時間（700ms）とカーブ（`easeOutBack`）を共通定義として新規追加
- /client/lib/ui/component/cavivara_portrait.dart
  - 額縁付き肖像画の表示アニメーションを共通定義に置き換え。`easeOutBack` のオーバーシュート対策として不透明度を `clamp` するよう修正
- /client/lib/ui/feature/home/home_screen.dart
  - トーク画面の入場アニメーションを、下からぬるっと浮き上がる演出（`easeOutBack`・スライド量と時間の見直し）に調整

## Screenshots & Demo

<!-- TODO: 作業指示者にて記載してください -->
