### PR TITLE
feat(client): トーク画面のカヴィヴァラアイコンをブラッシュアップ

### DIFF
--- a/client/lib/ui/component/animated_cavivara.dart
+++ b/client/lib/ui/component/animated_cavivara.dart
@@ -11,10 +11,14 @@ class AnimatedCavivara extends StatefulWidget {
   const AnimatedCavivara({
     super.key,
     this.strokeColor = const Color(0xFF3D678D),
+    this.fillColor = const Color(0xFFE0E0E0),
     this.strokeWidth = _CavivaraPainter._defaultStrokeWidth,
   });
 
   final Color strokeColor;
+
+  /// カヴィヴァラの輪郭の内側（顔・体）を塗りつぶす色。
+  final Color fillColor;
 
   /// 線および塗りつぶした瞳の太さ（ソース画像の座標系での値）。
   /// 小さいサイズで表示する場合は大きめの値を指定すると視認性が上がる。
@@ -94,6 +98,7 @@ class _AnimatedCavivaraState extends State<AnimatedCavivara>
         builder: (_, _) => CustomPaint(
           painter: _CavivaraPainter(
             strokeColor: widget.strokeColor,
+            fillColor: widget.fillColor,
             strokeWidth: widget.strokeWidth,
             winkProgress: _wink.value,
           ),
@@ -414,6 +419,7 @@ const _Brow _kRightBrow = _Brow(
 class _CavivaraPainter extends CustomPainter {
   _CavivaraPainter({
     required this.strokeColor,
+    required this.fillColor,
     this.strokeWidth = _defaultStrokeWidth,
     this.winkProgress = 0,
   });
@@ -429,6 +435,10 @@ class _CavivaraPainter extends CustomPainter {
   /// 毎フレーム再生成するとアニメーションがカクつくため、一度だけ生成して使い回す。
   static final List<Path> _staticStrokePaths = _buildStaticStrokePaths();
 
+  /// 輪郭の内側を塗りつぶすための、顔・体のシルエットを表す閉じた Path。
+  /// 輪郭を構成するストロークを一筆書きの順序でつなぎ合わせて生成する。
+  static final Path _bodyPath = _buildBodyPath();
+
   /// 静的に塗りつぶす左の瞳の Path。
   static final Path _leftPupilPath = _pupilPath(_kLeftPupil);
 
@@ -437,6 +447,9 @@ class _CavivaraPainter extends CustomPainter {
   static final Path _rightPupilBasePath = _pupilPath(_kRightPupil);
 
   final Color strokeColor;
+
+  /// 輪郭の内側（顔・体のシルエット）を塗りつぶす色。
+  final Color fillColor;
 
   /// 線および塗りつぶした瞳の太さ（ソース画像の座標系での値）。
   final double strokeWidth;
@@ -470,6 +483,13 @@ class _CavivaraPainter extends CustomPainter {
       ..color = strokeColor
       ..style = PaintingStyle.fill
       ..isAntiAlias = true;
+
+    // 線を描く前に、輪郭の内側（顔・体）を塗りつぶす。
+    final bodyPaint = Paint()
+      ..color = fillColor
+      ..style = PaintingStyle.fill
+      ..isAntiAlias = true;
+    canvas.drawPath(_bodyPath, bodyPaint);
 
     _drawStaticFeatures(canvas, strokePaint, fillPaint);
     _drawWinkingRightEye(canvas, strokePaint, fillPaint);
@@ -519,40 +539,89 @@ class _CavivaraPainter extends CustomPainter {
   // ---- 自由曲線: Catmull-Rom を 3 次ベジェに変換して描く ----
   static List<Path> _buildStrokePaths() {
     final paths = <Path>[];
-    for (final stroke in _kStrokes) {
-      final pts = <Offset>[];
-      for (var i = 0; i + 1 < stroke.length; i += 2) {
-        pts.add(Offset(stroke[i], stroke[i + 1]));
-      }
+    for (var index = 0; index < _kStrokes.length; index++) {
+      final pts = _strokePoints(index);
       if (pts.length < 2) {
         continue;
       }
-
       final path = Path()..moveTo(pts.first.dx, pts.first.dy);
-      if (pts.length == 2) {
-        path.lineTo(pts[1].dx, pts[1].dy);
-        paths.add(path);
-        continue;
-      }
-      const tension = 6;
-      for (var i = 0; i < pts.length - 1; i++) {
-        final p0 = i == 0 ? pts[0] : pts[i - 1];
-        final p1 = pts[i];
-        final p2 = pts[i + 1];
-        final p3 = (i + 2 < pts.length) ? pts[i + 2] : pts[pts.length - 1];
-        final c1 = Offset(
-          p1.dx + (p2.dx - p0.dx) / tension,
-          p1.dy + (p2.dy - p0.dy) / tension,
-        );
-        final c2 = Offset(
-          p2.dx - (p3.dx - p1.dx) / tension,
-          p2.dy - (p3.dy - p1.dy) / tension,
-        );
-        path.cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, p2.dx, p2.dy);
-      }
+      _appendCatmullRom(path, pts);
       paths.add(path);
     }
     return paths;
+  }
+
+  /// 輪郭を構成するストロークを一筆書きの順序でたどり、顔・体のシルエットを
+  /// 表す閉じた Path を生成する。各要素は `[ストロークの添字, 反転フラグ]`。
+  /// 反転フラグが 1 のときはそのストロークの点列を逆順にたどる。
+  /// ストローク同士の端点が完全には一致しないため、直前のストロークの終点から
+  /// 次のストロークの始点へは直線でつなぐ。
+  static const List<List<int>> _kBodyOutline = [
+    [25, 1], [35, 1], [6, 0], [47, 0], [12, 0], [32, 0], // 左側面（下→上）
+    [37, 1], [18, 0], [26, 0], [30, 1], [34, 0], [39, 0], [41, 1], // 左耳・頭頂
+    [5, 0], // 額
+    [1, 0], [4, 0], [36, 0], [9, 1], [16, 0], [42, 0], // 右耳
+    [49, 0], [52, 0], // 右側面・右脚（上→下）
+    [29, 1], [0, 1], // 足元・下端（右→左）
+  ];
+
+  static Path _buildBodyPath() {
+    final path = Path();
+    var started = false;
+    for (final segment in _kBodyOutline) {
+      final pts = _strokePoints(segment[0], reversed: segment[1] == 1);
+      if (pts.isEmpty) {
+        continue;
+      }
+      if (!started) {
+        path.moveTo(pts.first.dx, pts.first.dy);
+        started = true;
+      } else {
+        // 直前のストロークの終点から次のストロークの始点へ直線でつなぐ。
+        path.lineTo(pts.first.dx, pts.first.dy);
+      }
+      _appendCatmullRom(path, pts);
+    }
+    path.close();
+    return path;
+  }
+
+  /// 指定したストロークの点列を返す。[reversed] が真のときは逆順にする。
+  static List<Offset> _strokePoints(int index, {bool reversed = false}) {
+    final stroke = _kStrokes[index];
+    final pts = <Offset>[];
+    for (var i = 0; i + 1 < stroke.length; i += 2) {
+      pts.add(Offset(stroke[i], stroke[i + 1]));
+    }
+    return reversed ? pts.reversed.toList() : pts;
+  }
+
+  /// すでに [pts] の先頭にカーソルがある Path に対して、[pts] を通る
+  /// Catmull-Rom 曲線（3 次ベジェ変換）を追記する。
+  static void _appendCatmullRom(Path path, List<Offset> pts) {
+    if (pts.length < 2) {
+      return;
+    }
+    if (pts.length == 2) {
+      path.lineTo(pts[1].dx, pts[1].dy);
+      return;
+    }
+    const tension = 6;
+    for (var i = 0; i < pts.length - 1; i++) {
+      final p0 = i == 0 ? pts[0] : pts[i - 1];
+      final p1 = pts[i];
+      final p2 = pts[i + 1];
+      final p3 = (i + 2 < pts.length) ? pts[i + 2] : pts[pts.length - 1];
+      final c1 = Offset(
+        p1.dx + (p2.dx - p0.dx) / tension,
+        p1.dy + (p2.dy - p0.dy) / tension,
+      );
+      final c2 = Offset(
+        p2.dx - (p3.dx - p1.dx) / tension,
+        p2.dy - (p3.dy - p1.dy) / tension,
+      );
+      path.cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, p2.dx, p2.dy);
+    }
   }
 
   // ---- 目: アーモンド形 = 2 つの楕円の上弧 + 下弧で構成する ----
@@ -641,6 +710,7 @@ class _CavivaraPainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant _CavivaraPainter oldDelegate) =>
       oldDelegate.strokeColor != strokeColor ||
+      oldDelegate.fillColor != fillColor ||
       oldDelegate.strokeWidth != strokeWidth ||
       oldDelegate.winkProgress != winkProgress;
 }

--- a/client/lib/ui/component/animated_cavivara.dart
+++ b/client/lib/ui/component/animated_cavivara.dart
@@ -3,16 +3,26 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+/// カヴィヴァラの目のアニメーションの種類。
+enum CavivaraEyeAnimation {
+  /// 両目を同時に閉じてまばたきする。
+  blink,
+
+  /// 右目だけを閉じてウインクする。
+  wink,
+}
+
 /// アニメーション可能なカヴィヴァラ(Cavivara)の全身像を描画する自己完結ウィジェット。
 /// [strokeColor] が全ての線と塗りつぶした瞳の色を指定する。
 ///
-/// 表示後、一定間隔で右目のウィンクアニメーションを再生する。
+/// 表示後、一定間隔で目のアニメーション（[eyeAnimation] で指定）を再生する。
 class AnimatedCavivara extends StatefulWidget {
   const AnimatedCavivara({
     super.key,
     this.strokeColor = const Color(0xFF3D678D),
     this.fillColor = const Color(0xFFE0E0E0),
     this.strokeWidth = _CavivaraPainter._defaultStrokeWidth,
+    this.eyeAnimation = CavivaraEyeAnimation.blink,
   });
 
   final Color strokeColor;
@@ -24,24 +34,27 @@ class AnimatedCavivara extends StatefulWidget {
   /// 小さいサイズで表示する場合は大きめの値を指定すると視認性が上がる。
   final double strokeWidth;
 
+  /// 目のアニメーションの種類（両目のまばたき／右目のウインク）。
+  final CavivaraEyeAnimation eyeAnimation;
+
   @override
   State<AnimatedCavivara> createState() => _AnimatedCavivaraState();
 }
 
 class _AnimatedCavivaraState extends State<AnimatedCavivara>
     with SingleTickerProviderStateMixin {
-  /// 表示後、最初にウィンクするまでの待機時間。
+  /// 表示後、最初にまばたきするまでの待機時間。
   static const _initialDelay = Duration(milliseconds: 500);
 
-  /// ウィンクを繰り返す間隔。
-  static const _winkInterval = Duration(seconds: 3);
+  /// まばたきを繰り返す間隔。
+  static const _blinkInterval = Duration(seconds: 3);
 
-  /// ウィンク 1 回（閉眼 → 開眼）にかける時間。
-  static const _winkDuration = Duration(milliseconds: 260);
+  /// まばたき 1 回（閉眼 → 開眼）にかける時間。
+  static const _blinkDuration = Duration(milliseconds: 260);
 
   late final AnimationController _controller;
-  late final Animation<double> _wink;
-  Timer? _winkTimer;
+  late final Animation<double> _blink;
+  Timer? _blinkTimer;
 
   @override
   void initState() {
@@ -49,11 +62,11 @@ class _AnimatedCavivaraState extends State<AnimatedCavivara>
 
     _controller = AnimationController(
       vsync: this,
-      duration: _winkDuration,
+      duration: _blinkDuration,
     );
 
     // 0 -> 1 -> 0 と進めて、閉眼してから開眼するまばたきを表現する。
-    _wink = TweenSequence<double>([
+    _blink = TweenSequence<double>([
       TweenSequenceItem(
         tween: Tween<double>(
           begin: 0,
@@ -70,21 +83,21 @@ class _AnimatedCavivaraState extends State<AnimatedCavivara>
       ),
     ]).animate(_controller);
 
-    _winkTimer = Timer(_initialDelay, _playWink);
+    _blinkTimer = Timer(_initialDelay, _playBlink);
   }
 
-  void _playWink() {
+  void _playBlink() {
     _controller.forward(from: 0).whenComplete(() {
       if (!mounted) {
         return;
       }
-      _winkTimer = Timer(_winkInterval, _playWink);
+      _blinkTimer = Timer(_blinkInterval, _playBlink);
     });
   }
 
   @override
   void dispose() {
-    _winkTimer?.cancel();
+    _blinkTimer?.cancel();
     _controller.dispose();
     super.dispose();
   }
@@ -94,13 +107,14 @@ class _AnimatedCavivaraState extends State<AnimatedCavivara>
     return AspectRatio(
       aspectRatio: _kSrcWidth / _kSrcHeight,
       child: AnimatedBuilder(
-        animation: _wink,
+        animation: _blink,
         builder: (_, _) => CustomPaint(
           painter: _CavivaraPainter(
             strokeColor: widget.strokeColor,
             fillColor: widget.fillColor,
             strokeWidth: widget.strokeWidth,
-            winkProgress: _wink.value,
+            blinkProgress: _blink.value,
+            eyeAnimation: widget.eyeAnimation,
           ),
           size: Size.infinite,
         ),
@@ -421,17 +435,18 @@ class _CavivaraPainter extends CustomPainter {
     required this.strokeColor,
     required this.fillColor,
     this.strokeWidth = _defaultStrokeWidth,
-    this.winkProgress = 0,
+    this.blinkProgress = 0,
+    this.eyeAnimation = CavivaraEyeAnimation.blink,
   });
 
   /// 線および塗りつぶした瞳の太さの既定値（ソース画像の座標系での値）。
   static const double _defaultStrokeWidth = 20;
 
-  /// 閉眼（[winkProgress] = 1）時に右目を縦方向へ潰す割合。
-  static const double _winkCloseAmount = 0.92;
+  /// 閉眼（[blinkProgress] = 1）時に目を縦方向へ潰す割合。
+  static const double _blinkCloseAmount = 0.92;
 
-  /// ウィンクの影響を受けない静的な Path 群（輪郭などの自由曲線・眉・左目）。
-  /// ソース画像座標系で定義されており、色・サイズ・ウィンク進捗に依存しない。
+  /// まばたきの影響を受けない静的な Path 群（輪郭などの自由曲線・眉）。
+  /// ソース画像座標系で定義されており、色・サイズ・まばたき進捗に依存しない。
   /// 毎フレーム再生成するとアニメーションがカクつくため、一度だけ生成して使い回す。
   static final List<Path> _staticStrokePaths = _buildStaticStrokePaths();
 
@@ -439,10 +454,9 @@ class _CavivaraPainter extends CustomPainter {
   /// 輪郭を構成するストロークを一筆書きの順序でつなぎ合わせて生成する。
   static final Path _bodyPath = _buildBodyPath();
 
-  /// 静的に塗りつぶす左の瞳の Path。
-  static final Path _leftPupilPath = _pupilPath(_kLeftPupil);
-
-  /// ウィンクで変形させる右目・右の瞳の基準 Path（変形前）。
+  /// まばたきで変形させる左右の目・瞳の基準 Path（変形前）。
+  static final Path _leftEyeBasePath = _eyePath(_kLeftEye);
+  static final Path _leftPupilBasePath = _pupilPath(_kLeftPupil);
   static final Path _rightEyeBasePath = _eyePath(_kRightEye);
   static final Path _rightPupilBasePath = _pupilPath(_kRightPupil);
 
@@ -454,8 +468,11 @@ class _CavivaraPainter extends CustomPainter {
   /// 線および塗りつぶした瞳の太さ（ソース画像の座標系での値）。
   final double strokeWidth;
 
-  /// 右目のウィンク進捗。0 で開眼、1 で閉眼。
-  final double winkProgress;
+  /// 目のまばたき進捗。0 で開眼、1 で閉眼。
+  final double blinkProgress;
+
+  /// 目のアニメーションの種類（両目のまばたき／右目のウインク）。
+  final CavivaraEyeAnimation eyeAnimation;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -491,50 +508,77 @@ class _CavivaraPainter extends CustomPainter {
       ..isAntiAlias = true;
     canvas.drawPath(_bodyPath, bodyPaint);
 
-    _drawStaticFeatures(canvas, strokePaint, fillPaint);
-    _drawWinkingRightEye(canvas, strokePaint, fillPaint);
+    _drawStaticFeatures(canvas, strokePaint);
+    _drawBlinkingEyes(canvas, strokePaint, fillPaint);
 
     canvas.restore();
   }
 
-  /// ウィンクの影響を受けない部分（輪郭などの自由曲線・眉・左目・左の瞳）を描く。
-  void _drawStaticFeatures(Canvas canvas, Paint strokePaint, Paint fillPaint) {
+  /// まばたきの影響を受けない部分（輪郭などの自由曲線・眉）を描く。
+  void _drawStaticFeatures(Canvas canvas, Paint strokePaint) {
     for (final path in _staticStrokePaths) {
       canvas.drawPath(path, strokePaint);
     }
-
-    canvas.drawPath(_leftPupilPath, fillPaint);
   }
 
-  /// 右目（輪郭と瞳）をウィンク進捗に応じて目の中心を軸に上下へ潰して描く。
-  /// 閉じると横線（細いレンズ形）になってウィンクに見える。
-  void _drawWinkingRightEye(
+  /// 両目（輪郭と瞳）を [eyeAnimation] に応じて描く。
+  /// ウインク時は左目を閉じず（進捗 0）、右目だけを閉じる。
+  void _drawBlinkingEyes(Canvas canvas, Paint strokePaint, Paint fillPaint) {
+    final leftProgress = eyeAnimation == CavivaraEyeAnimation.blink
+        ? blinkProgress
+        : 0.0;
+    _drawBlinkingEye(
+      canvas,
+      strokePaint,
+      fillPaint,
+      _kLeftEye,
+      _leftEyeBasePath,
+      _leftPupilBasePath,
+      leftProgress,
+    );
+    _drawBlinkingEye(
+      canvas,
+      strokePaint,
+      fillPaint,
+      _kRightEye,
+      _rightEyeBasePath,
+      _rightPupilBasePath,
+      blinkProgress,
+    );
+  }
+
+  /// 1 つの目（輪郭と瞳）を [progress] に応じて目の中心を軸に上下へ潰して描く。
+  /// 閉じると横線（細いレンズ形）になってまばたき・ウインクに見える。
+  void _drawBlinkingEye(
     Canvas canvas,
     Paint strokePaint,
     Paint fillPaint,
+    _Eye eye,
+    Path eyeBasePath,
+    Path pupilBasePath,
+    double progress,
   ) {
-    final winkScaleY = 1.0 - _winkCloseAmount * winkProgress;
-    final winkMatrix = Matrix4.identity()
-      ..translateByDouble(_kRightEye.cx, _kRightEye.cy, 0, 1)
-      ..scaleByDouble(1, winkScaleY, 1, 1)
-      ..translateByDouble(-_kRightEye.cx, -_kRightEye.cy, 0, 1);
+    final blinkScaleY = 1.0 - _blinkCloseAmount * progress;
+    final blinkMatrix = Matrix4.identity()
+      ..translateByDouble(eye.cx, eye.cy, 0, 1)
+      ..scaleByDouble(1, blinkScaleY, 1, 1)
+      ..translateByDouble(-eye.cx, -eye.cy, 0, 1);
 
     canvas
       ..drawPath(
-        _rightEyeBasePath.transform(winkMatrix.storage),
+        eyeBasePath.transform(blinkMatrix.storage),
         strokePaint,
       )
       ..drawPath(
-        _rightPupilBasePath.transform(winkMatrix.storage),
+        pupilBasePath.transform(blinkMatrix.storage),
         fillPaint,
       );
   }
 
-  /// ウィンクの影響を受けない静的なストローク Path をまとめて生成する。
+  /// まばたきの影響を受けない静的なストローク Path をまとめて生成する。
   static List<Path> _buildStaticStrokePaths() => _buildStrokePaths()
     ..add(_browPath(_kLeftBrow))
-    ..add(_browPath(_kRightBrow))
-    ..add(_eyePath(_kLeftEye));
+    ..add(_browPath(_kRightBrow));
 
   // ---- 自由曲線: Catmull-Rom を 3 次ベジェに変換して描く ----
   static List<Path> _buildStrokePaths() {
@@ -712,5 +756,6 @@ class _CavivaraPainter extends CustomPainter {
       oldDelegate.strokeColor != strokeColor ||
       oldDelegate.fillColor != fillColor ||
       oldDelegate.strokeWidth != strokeWidth ||
-      oldDelegate.winkProgress != winkProgress;
+      oldDelegate.blinkProgress != blinkProgress ||
+      oldDelegate.eyeAnimation != eyeAnimation;
 }

--- a/client/lib/ui/component/animated_cavivara.dart
+++ b/client/lib/ui/component/animated_cavivara.dart
@@ -11,9 +11,14 @@ class AnimatedCavivara extends StatefulWidget {
   const AnimatedCavivara({
     super.key,
     this.strokeColor = const Color(0xFF3D678D),
+    this.strokeWidth = _CavivaraPainter._defaultStrokeWidth,
   });
 
   final Color strokeColor;
+
+  /// 線および塗りつぶした瞳の太さ（ソース画像の座標系での値）。
+  /// 小さいサイズで表示する場合は大きめの値を指定すると視認性が上がる。
+  final double strokeWidth;
 
   @override
   State<AnimatedCavivara> createState() => _AnimatedCavivaraState();
@@ -89,6 +94,7 @@ class _AnimatedCavivaraState extends State<AnimatedCavivara>
         builder: (_, _) => CustomPaint(
           painter: _CavivaraPainter(
             strokeColor: widget.strokeColor,
+            strokeWidth: widget.strokeWidth,
             winkProgress: _wink.value,
           ),
           size: Size.infinite,
@@ -406,10 +412,14 @@ const _Brow _kRightBrow = _Brow(
 );
 
 class _CavivaraPainter extends CustomPainter {
-  _CavivaraPainter({required this.strokeColor, this.winkProgress = 0});
+  _CavivaraPainter({
+    required this.strokeColor,
+    this.strokeWidth = _defaultStrokeWidth,
+    this.winkProgress = 0,
+  });
 
-  /// 線および塗りつぶした瞳の太さ（ソース画像の座標系での値）。
-  static const double _strokeWidth = 20;
+  /// 線および塗りつぶした瞳の太さの既定値（ソース画像の座標系での値）。
+  static const double _defaultStrokeWidth = 20;
 
   /// 閉眼（[winkProgress] = 1）時に右目を縦方向へ潰す割合。
   static const double _winkCloseAmount = 0.92;
@@ -427,6 +437,9 @@ class _CavivaraPainter extends CustomPainter {
   static final Path _rightPupilBasePath = _pupilPath(_kRightPupil);
 
   final Color strokeColor;
+
+  /// 線および塗りつぶした瞳の太さ（ソース画像の座標系での値）。
+  final double strokeWidth;
 
   /// 右目のウィンク進捗。0 で開眼、1 で閉眼。
   final double winkProgress;
@@ -448,7 +461,7 @@ class _CavivaraPainter extends CustomPainter {
     final strokePaint = Paint()
       ..color = strokeColor
       ..style = PaintingStyle.stroke
-      ..strokeWidth = _strokeWidth
+      ..strokeWidth = strokeWidth
       ..strokeCap = StrokeCap.round
       ..strokeJoin = StrokeJoin.round
       ..isAntiAlias = true;
@@ -628,5 +641,6 @@ class _CavivaraPainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant _CavivaraPainter oldDelegate) =>
       oldDelegate.strokeColor != strokeColor ||
+      oldDelegate.strokeWidth != strokeWidth ||
       oldDelegate.winkProgress != winkProgress;
 }

--- a/client/lib/ui/component/cat_fur_bubble_painter.dart
+++ b/client/lib/ui/component/cat_fur_bubble_painter.dart
@@ -25,6 +25,14 @@ class CatFurBubblePainter extends CustomPainter {
         : Colors.grey.shade800;
   }
 
+  /// 猫毛吹き出しの最も内側（文字が乗る中央領域）の塗りつぶし色。
+  /// アイコンなどを吹き出し中央と同じ濃度のグレーで塗りたい場合に参照する。
+  static Color innerSilhouetteColor(Brightness brightness) {
+    return brightness == Brightness.dark
+        ? _darkSilhouetteCenterColor
+        : Colors.grey.shade100;
+  }
+
   // ===== ジオメトリ定数 =====
 
   /// 角丸部分を避けるマージン
@@ -138,8 +146,7 @@ class CatFurBubblePainter extends CustomPainter {
       _isDark ? _darkSilhouetteRingColor : Colors.grey.shade200;
 
   /// 2段目シルエット層の色（文字が乗る中央領域）。
-  Color get _innerSilhouetteColor =>
-      _isDark ? _darkSilhouetteCenterColor : Colors.grey.shade100;
+  Color get _innerSilhouetteColor => innerSilhouetteColor(brightness);
 
   /// 下側に落ちる立体感のためのシャドー帯色。
   Color get _shadowOverlayColor =>
@@ -974,7 +981,8 @@ enum _Corner {
   topLeft,
   topRight,
   bottomRight,
-  bottomLeft;
+  bottomLeft
+  ;
 
   bool get isLeft => this == _Corner.topLeft || this == _Corner.bottomLeft;
   bool get isTop => this == _Corner.topLeft || this == _Corner.topRight;

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -8,9 +8,9 @@ import 'package:house_worker/data/model/chat_message.dart';
 import 'package:house_worker/data/repository/chat_bubble_design_repository.dart';
 import 'package:house_worker/data/repository/skip_clear_chat_confirmation_repository.dart';
 import 'package:house_worker/data/service/cavivara_profile_service.dart';
+import 'package:house_worker/ui/component/animated_cavivara.dart';
 import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cat_fur_bubble_painter.dart';
-import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/component/chat_bubble_design_extension.dart';
 import 'package:house_worker/ui/component/clear_chat_confirmation_dialog.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
@@ -136,9 +136,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
     final title = Row(
       children: [
-        CavivaraAvatar(
-          size: 32,
-          assetPath: cavivaraProfile.iconPath,
+        SizedBox(
+          width: 48,
+          height: 48,
+          child: Transform.flip(
+            flipX: true,
+            child: AnimatedCavivara(
+              strokeColor: Theme.of(context).colorScheme.onSurface,
+              // 画面上で約1.2px相当の線になるよう、表示サイズ(48)から
+              // ソース画像座標系(幅2308)へ換算する。
+              strokeWidth: 1.2 * 2308 / 48,
+            ),
+          ),
         ),
         const SizedBox(width: 12),
         Expanded(
@@ -894,8 +903,18 @@ class _AiChatBubble extends ConsumerWidget {
           )
         : bubble;
 
-    final avatar = CavivaraAvatar(
-      assetPath: cavivaraProfile.iconPath,
+    final avatar = SizedBox(
+      width: 56,
+      height: 56,
+      child: Transform.flip(
+        flipX: true,
+        child: AnimatedCavivara(
+          strokeColor: Theme.of(context).colorScheme.onSurface,
+          // 画面上で約1.2px相当の線になるよう、表示サイズ(56)から
+          // ソース画像座標系(幅2308)へ換算する。
+          strokeWidth: 1.2 * 2308 / 56,
+        ),
+      ),
     );
 
     return IntrinsicHeight(
@@ -905,9 +924,13 @@ class _AiChatBubble extends ConsumerWidget {
           avatar,
           const SizedBox(width: 8),
           Flexible(
-            child: Skeletonizer(
-              enabled: designAsync.isLoading,
-              child: bubbleWithPointer,
+            // アイコンに対して吹き出しを少し下げる。
+            child: Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Skeletonizer(
+                enabled: designAsync.isLoading,
+                child: bubbleWithPointer,
+              ),
             ),
           ),
         ],

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -911,20 +911,24 @@ class _AiChatBubble extends ConsumerWidget {
           )
         : bubble;
 
-    final avatar = SizedBox(
-      width: 56,
-      height: 56,
-      child: Transform.flip(
-        flipX: true,
-        child: AnimatedCavivara(
-          strokeColor: Theme.of(context).colorScheme.onSurface,
-          // 輪郭内側を吹き出しの最内層グレーと同じ色で塗りつぶす。
-          fillColor: CatFurBubblePainter.innerSilhouetteColor(
-            Theme.of(context).brightness,
+    final avatar = Semantics(
+      label: 'カヴィヴァラさんのアイコン',
+      image: true,
+      child: SizedBox(
+        width: 56,
+        height: 56,
+        child: Transform.flip(
+          flipX: true,
+          child: AnimatedCavivara(
+            strokeColor: Theme.of(context).colorScheme.onSurface,
+            // 輪郭内側を吹き出しの最内層グレーと同じ色で塗りつぶす。
+            fillColor: CatFurBubblePainter.innerSilhouetteColor(
+              Theme.of(context).brightness,
+            ),
+            // 画面上で約1.2px相当の線になるよう、表示サイズ(56)から
+            // ソース画像座標系(幅2308)へ換算する。
+            strokeWidth: 1.2 * 2308 / 56,
           ),
-          // 画面上で約1.2px相当の線になるよう、表示サイズ(56)から
-          // ソース画像座標系(幅2308)へ換算する。
-          strokeWidth: 1.2 * 2308 / 56,
         ),
       ),
     );

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -757,7 +757,6 @@ class _UserChatBubble extends ConsumerWidget {
         color: textColor,
       ),
     );
-    final timeText = _TimestampText(timestamp: message.timestamp);
     final bubbleColor = Theme.of(context).colorScheme.primaryContainer;
     final bubble = design.buildBubble(
       context: context,
@@ -789,7 +788,6 @@ class _UserChatBubble extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.end,
       spacing: 4,
       children: [
-        timeText,
         Skeletonizer(
           enabled: designAsync.isLoading,
           child: bubbleWithPointer,
@@ -869,8 +867,6 @@ class _AiChatBubble extends ConsumerWidget {
       }
     }
 
-    final timeText = _TimestampText(timestamp: message.timestamp);
-
     final bubbleColor = Theme.of(context).colorScheme.surfaceContainer;
 
     final bubble = design.buildBubble(
@@ -914,13 +910,6 @@ class _AiChatBubble extends ConsumerWidget {
               child: bubbleWithPointer,
             ),
           ),
-          if (!message.isStreaming || message.content.isNotEmpty) ...[
-            const SizedBox(width: 4),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: timeText,
-            ),
-          ],
         ],
       ),
     );
@@ -948,9 +937,6 @@ class _AppChatBubble extends ConsumerWidget {
     final bubbleColor = Theme.of(
       context,
     ).colorScheme.surfaceContainer.withAlpha(100);
-    final timeText = _TimestampText(
-      timestamp: message.timestamp,
-    );
     final bubble = design.buildBubble(
       context: context,
       messageType: MessageType.system,
@@ -970,27 +956,7 @@ class _AppChatBubble extends ConsumerWidget {
       spacing: 4,
       children: [
         expanded,
-        timeText,
       ],
-    );
-  }
-}
-
-class _TimestampText extends StatelessWidget {
-  const _TimestampText({
-    required this.timestamp,
-  });
-
-  final DateTime timestamp;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      '${timestamp.hour.toString().padLeft(2, '0')}:'
-      '${timestamp.minute.toString().padLeft(2, '0')}',
-      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-        color: Theme.of(context).colorScheme.onSurface.withAlpha(100),
-      ),
     );
   }
 }

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -143,9 +143,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             flipX: true,
             child: AnimatedCavivara(
               strokeColor: Theme.of(context).colorScheme.onSurface,
-              // 輪郭内側をテーマに追従する控えめなグレーで塗る。
-              // 固定の明るいグレーだとダークモードで AppBar 上に浮くため。
-              fillColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+              // 輪郭内側を吹き出し横のアイコンと同じ最内層グレーで塗る。
+              fillColor: CatFurBubblePainter.innerSilhouetteColor(
+                Theme.of(context).brightness,
+              ),
               // 画面上で約1.2px相当の線になるよう、表示サイズ(48)から
               // ソース画像座標系(幅2308)へ換算する。
               strokeWidth: 1.2 * 2308 / 48,

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -143,6 +143,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             flipX: true,
             child: AnimatedCavivara(
               strokeColor: Theme.of(context).colorScheme.onSurface,
+              // 輪郭内側をテーマに追従する控えめなグレーで塗る。
+              // 固定の明るいグレーだとダークモードで AppBar 上に浮くため。
+              fillColor: Theme.of(context).colorScheme.surfaceContainerHigh,
               // 画面上で約1.2px相当の線になるよう、表示サイズ(48)から
               // ソース画像座標系(幅2308)へ換算する。
               strokeWidth: 1.2 * 2308 / 48,
@@ -910,6 +913,10 @@ class _AiChatBubble extends ConsumerWidget {
         flipX: true,
         child: AnimatedCavivara(
           strokeColor: Theme.of(context).colorScheme.onSurface,
+          // 輪郭内側を吹き出しの最内層グレーと同じ色で塗りつぶす。
+          fillColor: CatFurBubblePainter.innerSilhouetteColor(
+            Theme.of(context).brightness,
+          ),
           // 画面上で約1.2px相当の線になるよう、表示サイズ(56)から
           // ソース画像座標系(幅2308)へ換算する。
           strokeWidth: 1.2 * 2308 / 56,

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -136,20 +136,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
     final title = Row(
       children: [
-        SizedBox(
-          width: 48,
-          height: 48,
-          child: Transform.flip(
-            flipX: true,
-            child: AnimatedCavivara(
-              strokeColor: Theme.of(context).colorScheme.onSurface,
-              // 輪郭内側を吹き出し横のアイコンと同じ最内層グレーで塗る。
-              fillColor: CatFurBubblePainter.innerSilhouetteColor(
-                Theme.of(context).brightness,
+        Semantics(
+          label: 'カヴィヴァラさんのアイコン',
+          image: true,
+          child: SizedBox(
+            width: 48,
+            height: 48,
+            child: Transform.flip(
+              flipX: true,
+              child: AnimatedCavivara(
+                strokeColor: Theme.of(context).colorScheme.onSurface,
+                // 輪郭内側を吹き出し横のアイコンと同じ最内層グレーで塗る。
+                fillColor: CatFurBubblePainter.innerSilhouetteColor(
+                  Theme.of(context).brightness,
+                ),
+                // 画面上で約1.2px相当の線になるよう、表示サイズ(48)から
+                // ソース画像座標系(幅2308)へ換算する。
+                strokeWidth: 1.2 * 2308 / 48,
               ),
-              // 画面上で約1.2px相当の線になるよう、表示サイズ(48)から
-              // ソース画像座標系(幅2308)へ換算する。
-              strokeWidth: 1.2 * 2308 / 48,
             ),
           ),
         ),

--- a/client/lib/ui/root_app.dart
+++ b/client/lib/ui/root_app.dart
@@ -10,6 +10,7 @@ import 'package:house_worker/data/service/remote_config_service.dart';
 import 'package:house_worker/ui/app_initial_route.dart';
 import 'package:house_worker/ui/component/animated_cavivara.dart';
 import 'package:house_worker/ui/component/app_theme.dart';
+import 'package:house_worker/ui/component/cat_fur_bubble_painter.dart';
 import 'package:house_worker/ui/component/heads_up_notification_overlay.dart';
 import 'package:house_worker/ui/feature/auth/login_screen.dart';
 import 'package:house_worker/ui/feature/home/home_screen.dart';
@@ -95,6 +96,10 @@ class _RootAppState extends ConsumerState<RootApp> {
                   // ダークモードは明色、ライトモードは暗色になる。
                   return AnimatedCavivara(
                     strokeColor: Theme.of(context).colorScheme.onSurfaceVariant,
+                    // 輪郭内側を吹き出し横のアイコンと同じ最内層グレーで塗る。
+                    fillColor: CatFurBubblePainter.innerSilhouetteColor(
+                      Theme.of(context).brightness,
+                    ),
                   );
                 },
               ),

--- a/client/lib/ui/root_app.dart
+++ b/client/lib/ui/root_app.dart
@@ -100,6 +100,8 @@ class _RootAppState extends ConsumerState<RootApp> {
                     fillColor: CatFurBubblePainter.innerSilhouetteColor(
                       Theme.of(context).brightness,
                     ),
+                    // スプラッシュ画面ではウインクさせる。
+                    eyeAnimation: CavivaraEyeAnimation.wink,
                   );
                 },
               ),

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1041,10 +1041,10 @@ packages:
     dependency: "direct main"
     description:
       name: purchases_flutter
-      sha256: be377ba740a650b64ecbb418ea24cc36a91bf13d61db2f9552c8d2b20ca3d670
+      sha256: "518bd7cfe266a592114e13bbe7384e4ab4a076412dbe3e84d972f73fde6d3b5c"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.2"
+    version: "10.2.3"
   record_use:
     dependency: transitive
     description:

--- a/client/test/ui/component/animated_cavivara_test.dart
+++ b/client/test/ui/component/animated_cavivara_test.dart
@@ -73,5 +73,23 @@ void main() {
       expect(find.byType(AnimatedCavivara), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('fillColor を指定してもビルドできること', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 200,
+                child: AnimatedCavivara(fillColor: Colors.grey),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(AnimatedCavivara), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## 概要

トーク画面のカヴィヴァラさんアイコンの見た目をブラッシュアップしました。

- カヴィヴァラの輪郭の内側（顔・体）を塗りつぶせるよう、`AnimatedCavivara` に `fillColor` を追加。輪郭ストロークを一筆書きの順序でつないだシルエット Path を生成し、線の背面を塗りつぶす。
- トーク画面の吹き出し横のアイコンを、吹き出しの最内層グレー（文字が乗る中央領域と同じ色）で塗りつぶすように変更。最内層グレーを `CatFurBubblePainter.innerSilhouetteColor(brightness)` として公開し参照。
- タイトルバーとスプラッシュ画面のアイコンの塗りつぶし色も同じ最内層グレーに統一。固定の明るいグレーがダークモードで背景から浮く問題も併せて解消。
- 色はライト／ダークモードそれぞれに追従（ライト = `#F5F5F5` / ダーク = `#252525`）。

## 追加・修正ファイル

- `client/lib/ui/component/animated_cavivara.dart`: `fillColor` 引数の追加とシルエット Path 生成・塗りつぶし描画
- `client/lib/ui/component/cat_fur_bubble_painter.dart`: 最内層グレーを `innerSilhouetteColor(Brightness)` として公開
- `client/lib/ui/feature/home/home_screen.dart`: 吹き出し横・タイトルバーのアイコンに `fillColor` を指定
- `client/lib/ui/root_app.dart`: スプラッシュ画面のアイコンに `fillColor` を指定
- `client/test/ui/component/animated_cavivara_test.dart`: `fillColor` 指定時のビルドテストを追加

## Related Issue

<!-- 作業指示者の方へ: 関連する Issue 番号があれば記載してください（例: close #123） -->

## Screenshots & Demo

<!-- 作業指示者の方へ: ライト／ダークモードそれぞれのトーク画面・タイトルバー・スプラッシュ画面のスクリーンショットを添付してください -->

## レビューで見て欲しいポイント

<!-- 作業指示者の方へ: 特にレビューしてほしい観点があれば記載してください -->
