### PR TITLE
fix: 業績画面をナビゲーションスタックの最下層に配置する

### DIFF
--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -211,7 +211,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           );
         },
         onSelectAchievement: () {
-          Navigator.of(context).push(UserStatisticsScreen.route());
+          Navigator.of(context).pushAndRemoveUntil(
+            UserStatisticsScreen.route(),
+            (route) => false,
+          );
         },
         onSelectSettings: () {
           Navigator.of(context).push(SettingsScreen.route());

--- a/client/lib/ui/feature/stats/user_statistics_screen.dart
+++ b/client/lib/ui/feature/stats/user_statistics_screen.dart
@@ -54,7 +54,10 @@ class UserStatisticsScreen extends ConsumerWidget {
           );
         },
         onSelectAchievement: () {
-          Navigator.of(context).pop();
+          Navigator.of(context).pushAndRemoveUntil(
+            UserStatisticsScreen.route(),
+            (route) => false,
+          );
         },
         onSelectSettings: () {
           Navigator.of(context).push(SettingsScreen.route());


### PR DESCRIPTION
## 概要

左ドロワーメニューからトーク→業績と移り変わった際、左端スワイプでトークに戻れないよう、業績画面をスタック最下層に配置する。

Closes #365

Generated with [Claude Code](https://claude.ai/code)