### PR TITLE
feat(client): Prod のリリースビルドではトーク画面のエラー詳細を非表示にする

### DIFF
--- a/client/lib/data/definition/app_feature.dart
+++ b/client/lib/data/definition/app_feature.dart
@@ -9,6 +9,13 @@ final bool showCustomAppBanner =
 
 final useFirebaseEmulator = flavor == Flavor.emulator;
 
+/// エラーの詳細内容を UI に表示するか否か
+///
+/// 一般公開アプリのリリースビルドでは、内部的なエラー詳細をユーザーに見せないため表示しない。
+/// `kReleaseMode` を先に評価することで、`FLUTTER_APP_FLAVOR` 未指定のテスト環境では
+/// 例外を投げる `flavor` の参照を回避する。
+final bool showsErrorDetail = !(kReleaseMode && flavor == Flavor.prod);
+
 const bool isAnalyticsEnabled =
     String.fromEnvironment('ENABLE_ANALYTICS') == 'true' || kReleaseMode;
 

--- a/client/lib/data/definition/app_feature.dart
+++ b/client/lib/data/definition/app_feature.dart
@@ -14,7 +14,7 @@ final useFirebaseEmulator = flavor == Flavor.emulator;
 /// 一般公開アプリのリリースビルドでは、内部的なエラー詳細をユーザーに見せないため表示しない。
 /// `kReleaseMode` を先に評価することで、`FLUTTER_APP_FLAVOR` 未指定のテスト環境では
 /// 例外を投げる `flavor` の参照を回避する。
-final bool showsErrorDetail = !(kReleaseMode && flavor == Flavor.prod);
+final bool showErrorDetail = !(kReleaseMode && flavor == Flavor.prod);
 
 const bool isAnalyticsEnabled =
     String.fromEnvironment('ENABLE_ANALYTICS') == 'true' || kReleaseMode;

--- a/client/lib/ui/feature/home/home_presenter.dart
+++ b/client/lib/ui/feature/home/home_presenter.dart
@@ -134,7 +134,7 @@ class ChatMessages extends _$ChatMessages {
         case SendMessageExceptionUncategorized(message: final errorMessage):
           // 一般公開アプリのリリースビルドでは、内部的なエラー詳細をユーザーに見せない
           const baseMessage = '原因不明のエラーが発生しました。カヴィヴァラさんが疲れているのかもしれません';
-          final content = showsErrorDetail
+          final content = showErrorDetail
               ? '$baseMessage: $errorMessage'
               : baseMessage;
           updateAiMessage(

--- a/client/lib/ui/feature/home/home_presenter.dart
+++ b/client/lib/ui/feature/home/home_presenter.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:house_worker/data/definition/app_feature.dart';
 import 'package:house_worker/data/model/chat_message.dart';
 import 'package:house_worker/data/model/send_message_exception.dart';
 import 'package:house_worker/data/model/supporter_title.dart';
@@ -45,9 +46,7 @@ class ChatMessages extends _$ChatMessages {
     state = [...state, userMessage];
 
     unawaited(
-      ref
-          .read(hasEverSentMessageRepositoryProvider.notifier)
-          .markAsSent(),
+      ref.read(hasEverSentMessageRepositoryProvider.notifier).markAsSent(),
     );
 
     final aiChatService = ref.read(aiChatServiceProvider);
@@ -133,9 +132,14 @@ class ChatMessages extends _$ChatMessages {
           );
 
         case SendMessageExceptionUncategorized(message: final errorMessage):
+          // 一般公開アプリのリリースビルドでは、内部的なエラー詳細をユーザーに見せない
+          const baseMessage = '原因不明のエラーが発生しました。カヴィヴァラさんが疲れているのかもしれません';
+          final content = showsErrorDetail
+              ? '$baseMessage: $errorMessage'
+              : baseMessage;
           updateAiMessage(
             (message) => message.copyWith(
-              content: '原因不明のエラーが発生しました。カヴィヴァラさんが疲れているのかもしれません: $errorMessage',
+              content: content,
               sender: const ChatMessageSender.app(),
               timestamp: DateTime.now(),
               isStreaming: false,


### PR DESCRIPTION
## 概要

トーク画面でエラーが発生した際、これまではエラーの詳細（description）を画面に表示していました。
本 PR では、**Prod 環境のリリースビルドの場合のみ**、内部的なエラー詳細をユーザーに表示しないようにします。それ以外（dev / emulator、デバッグビルド）では従来どおりエラー詳細を表示し、開発時の調査を容易にします。

- `原因不明のエラーが発生しました。カヴィヴァラさんが疲れているのかもしれません`
  - Prod リリースビルド: 上記のみ表示（詳細なし）
  - それ以外: 従来どおり `: {エラー詳細}` を付与して表示

なお、この種のエラーの Crashlytics へのレポート送信は `ai_chat_service.dart` で既に実装済みのため、本 PR での追加対応はありません。

## 追加・修正ファイル

- `client/lib/data/definition/app_feature.dart`
  - エラー詳細を UI に表示するか否かを判定するフラグ `showsErrorDetail` を追加。
  - `kReleaseMode` を先に評価する短絡評価とし、`FLUTTER_APP_FLAVOR` 未指定で例外を投げる `flavor` の参照をテスト環境で回避。
- `client/lib/ui/feature/home/home_presenter.dart`
  - 原因不明のエラー（`SendMessageExceptionUncategorized`）発生時、`showsErrorDetail` に応じてエラー詳細の表示を切り替え。

## Related Issue

<!-- 作業指示者の方へ: 関連する Issue 番号があれば記載してください（例: close #123） -->

## Screenshots & Demo

<!-- 作業指示者の方へ: 必要に応じて、Prod リリースビルド時とそれ以外でのエラー表示の差分がわかるスクリーンショット/動画を添付してください -->

## レビューで見て欲しいポイント

<!-- 作業指示者の方へ: レビュアーに特に確認してほしい観点があれば記載してください -->

## テスト

- `flutter test test/ui/feature/home/home_presenter_test.dart` 全 15 件パス
- `dart format` / `dart analyze` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)