### PR TITLE
feat: 初回起動バッジを獲得する機能を追加する

### DIFF
--- a/client/lib/data/model/app_badge.dart
+++ b/client/lib/data/model/app_badge.dart
@@ -1,0 +1,5 @@
+/// アプリ内バッジの種類
+enum AppBadge {
+  /// 初回起動時に獲得できるバッジ
+  firstLaunch,
+}

--- a/client/lib/data/model/earned_badge.dart
+++ b/client/lib/data/model/earned_badge.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:house_worker/data/model/app_badge.dart';
+
+part 'earned_badge.freezed.dart';
+part 'earned_badge.g.dart';
+
+/// 獲得済みバッジを表すモデル
+@freezed
+abstract class EarnedBadge with _$EarnedBadge {
+  const factory EarnedBadge({
+    required AppBadge badge,
+    required DateTime earnedAt,
+  }) = _EarnedBadge;
+
+  factory EarnedBadge.fromJson(Map<String, dynamic> json) =>
+      _$EarnedBadgeFromJson(json);
+}

--- a/client/lib/data/model/preference_key.dart
+++ b/client/lib/data/model/preference_key.dart
@@ -4,4 +4,5 @@ enum PreferenceKey {
   totalVivaPoint,
   supportHistoryList,
   loginBonusGrantedDates,
+  earnedBadgeList,
 }

--- a/client/lib/data/repository/earned_badges_repository.dart
+++ b/client/lib/data/repository/earned_badges_repository.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:house_worker/data/model/earned_badge.dart';
+import 'package:house_worker/data/model/preference_key.dart';
+import 'package:house_worker/data/service/preference_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earned_badges_repository.g.dart';
+
+/// 獲得済みバッジの一覧を永続化するリポジトリ
+@riverpod
+class EarnedBadgesRepository extends _$EarnedBadgesRepository {
+  @override
+  Future<List<EarnedBadge>> build() async {
+    final preferenceService = ref.read(preferenceServiceProvider);
+    final jsonString = await preferenceService.getString(
+      PreferenceKey.earnedBadgeList,
+    );
+
+    if (jsonString == null || jsonString.isEmpty) {
+      return [];
+    }
+
+    final jsonList = jsonDecode(jsonString) as List<dynamic>;
+    return jsonList
+        .map((json) => EarnedBadge.fromJson(json as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// バッジを追加する（最新が先頭）
+  Future<void> add(EarnedBadge badge) async {
+    final preferenceService = ref.read(preferenceServiceProvider);
+    final current = await future;
+
+    final updated = [badge, ...current];
+
+    final jsonList = updated.map((b) => b.toJson()).toList();
+    final jsonString = jsonEncode(jsonList);
+
+    await preferenceService.setString(
+      PreferenceKey.earnedBadgeList,
+      value: jsonString,
+    );
+
+    if (!ref.mounted) {
+      return;
+    }
+
+    state = AsyncValue.data(updated);
+  }
+}

--- a/client/lib/data/repository/earned_badges_repository.dart
+++ b/client/lib/data/repository/earned_badges_repository.dart
@@ -48,4 +48,15 @@ class EarnedBadgesRepository extends _$EarnedBadgesRepository {
 
     state = AsyncValue.data(updated);
   }
+
+  /// 獲得済みバッジの一覧をリセットする (デバッグ用)
+  Future<void> resetForDebug() async {
+    final preferenceService = ref.read(preferenceServiceProvider);
+    await preferenceService.remove(PreferenceKey.earnedBadgeList);
+
+    if (!ref.mounted) {
+      return;
+    }
+    state = const AsyncValue.data(<EarnedBadge>[]);
+  }
 }

--- a/client/lib/ui/component/app_badge_extension.dart
+++ b/client/lib/ui/component/app_badge_extension.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:house_worker/data/model/app_badge.dart';
+
+extension AppBadgeExtension on AppBadge {
+  String get displayName => switch (this) {
+    AppBadge.firstLaunch => 'カヴィヴァラの世界に足を踏み入れる',
+  };
+
+  IconData get icon => switch (this) {
+    AppBadge.firstLaunch => Icons.emoji_events,
+  };
+}

--- a/client/lib/ui/component/app_badge_extension.dart
+++ b/client/lib/ui/component/app_badge_extension.dart
@@ -9,4 +9,8 @@ extension AppBadgeExtension on AppBadge {
   IconData get icon => switch (this) {
     AppBadge.firstLaunch => Icons.emoji_events,
   };
+
+  String get description => switch (this) {
+    AppBadge.firstLaunch => 'アプリを始めて起動しました。',
+  };
 }

--- a/client/lib/ui/component/app_badge_extension.dart
+++ b/client/lib/ui/component/app_badge_extension.dart
@@ -7,7 +7,17 @@ extension AppBadgeExtension on AppBadge {
   };
 
   IconData get icon => switch (this) {
-    AppBadge.firstLaunch => Icons.emoji_events,
+    // 「足を踏み入れる」をモチーフにした歩くアイコン
+    AppBadge.firstLaunch => Icons.directions_walk,
+  };
+
+  /// バッジの背景に使うグラデーション色（左上→右下）
+  List<Color> get gradientColors => switch (this) {
+    AppBadge.firstLaunch => const [
+      Color(0xFFFFE082),
+      Color(0xFFFFB300),
+      Color(0xFFEF6C00),
+    ],
   };
 
   String get description => switch (this) {

--- a/client/lib/ui/component/app_badge_icon.dart
+++ b/client/lib/ui/component/app_badge_icon.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:house_worker/data/model/app_badge.dart';
+import 'package:house_worker/ui/component/app_badge_extension.dart';
+
+/// バッジを正方形のリッチな見た目で表示するウィジェット
+class AppBadgeIcon extends StatelessWidget {
+  const AppBadgeIcon({
+    required this.badge,
+    required this.size,
+    super.key,
+  });
+
+  final AppBadge badge;
+
+  /// 正方形の一辺の長さ
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = badge.gradientColors;
+
+    // 角丸の正方形の外形
+    final shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(size * 0.24),
+    );
+
+    // 立体感を出すための影
+    final shadow = BoxShadow(
+      color: colors.last.withValues(alpha: 0.4),
+      blurRadius: size * 0.16,
+      offset: Offset(0, size * 0.08),
+    );
+
+    // アイコンの背面に敷く半透明の円（リッチさを演出）
+    final iconBackdrop = Container(
+      width: size * 0.62,
+      height: size * 0.62,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.18),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(
+        badge.icon,
+        size: size * 0.42,
+        color: Colors.white,
+      ),
+    );
+
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: ShapeDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: colors,
+        ),
+        shape: shape.copyWith(
+          side: BorderSide(
+            color: Colors.white.withValues(alpha: 0.6),
+            width: size * 0.03,
+          ),
+        ),
+        shadows: [shadow],
+      ),
+      child: iconBackdrop,
+    );
+  }
+}

--- a/client/lib/ui/feature/home/home_presenter.dart
+++ b/client/lib/ui/feature/home/home_presenter.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 
 import 'package:house_worker/data/definition/app_feature.dart';
+import 'package:house_worker/data/model/app_badge.dart';
 import 'package:house_worker/data/model/chat_message.dart';
+import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/data/model/send_message_exception.dart';
 import 'package:house_worker/data/model/supporter_title.dart';
+import 'package:house_worker/data/repository/earned_badges_repository.dart';
 import 'package:house_worker/data/repository/has_ever_sent_message_repository.dart';
 import 'package:house_worker/data/repository/login_bonus_granted_dates_repository.dart';
 import 'package:house_worker/data/repository/viva_point_repository.dart';
@@ -302,5 +305,41 @@ class AwardDailyLoginBonus extends _$AwardDailyLoginBonus {
     ref
         .read(headsUpNotificationProvider.notifier)
         .showDailyLoginBonus(earnedVP: _dailyLoginBonusVP);
+  }
+}
+
+/// アプリ初回起動時にバッジを付与するプロバイダー。
+///
+/// 初回起動バッジがまだ付与されていない場合は付与して返す。
+/// すでに付与済みの場合は null を返す。
+@riverpod
+class AwardFirstLaunchBadge extends _$AwardFirstLaunchBadge {
+  @override
+  Future<EarnedBadge?> build() async {
+    final earnedBadges = await ref.read(
+      earnedBadgesRepositoryProvider.future,
+    );
+
+    // 初回起動バッジがすでに付与済みかチェック
+    final hasFirstLaunchBadge = earnedBadges.any(
+      (b) => b.badge == AppBadge.firstLaunch,
+    );
+    if (hasFirstLaunchBadge) {
+      return null;
+    }
+
+    // バッジを付与
+    final badge = EarnedBadge(
+      badge: AppBadge.firstLaunch,
+      earnedAt: DateTime.now(),
+    );
+
+    await ref.read(earnedBadgesRepositoryProvider.notifier).add(badge);
+
+    if (!ref.mounted) {
+      return null;
+    }
+
+    return badge;
   }
 }

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -106,11 +106,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                 if (!mounted) {
                   return;
                 }
-                await BadgeAcquiredDialog.show(context, earnedBadge: badge);
-                if (!mounted) {
-                  return;
+                try {
+                  await BadgeAcquiredDialog.show(context, earnedBadge: badge);
+                } finally {
+                  if (mounted) {
+                    _activateDailyBonusIfNeeded();
+                  }
                 }
-                _activateDailyBonusIfNeeded();
               });
             } else {
               _activateDailyBonusIfNeeded();

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -16,6 +16,7 @@ import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
 import 'package:house_worker/ui/component/suggested_reply_list.dart';
 import 'package:house_worker/ui/feature/home/home_presenter.dart';
 import 'package:house_worker/ui/feature/settings/settings_screen.dart';
+import 'package:house_worker/ui/feature/stats/badge_acquired_dialog.dart';
 import 'package:house_worker/ui/feature/stats/user_statistics_screen.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -51,6 +52,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   bool _isMessageEmpty = true;
   bool _shouldShowSuggestions = false;
   Timer? _suggestionTimer;
+
+  /// ログインボーナスがすでに有効化済みかどうか。
+  ///
+  /// バッジダイアログの表示後にログインボーナスを開始するため、重複起動を防ぐフラグ。
+  bool _dailyBonusActivated = false;
 
   late final AnimationController _entranceController;
   late final Animation<double> _entranceFade;
@@ -90,9 +96,42 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       ..listenManual(awardFirstMessageBonusProvider, (_, _) {
         // Providerの副作用のみを利用するため、何もしない
       })
-      ..listenManual(awardDailyLoginBonusProvider, (_, _) {
-        // Providerの副作用のみを利用するため、何もしない
+      // バッジダイアログ → ログインボーナス通知の順に表示するため、
+      // ログインボーナスの有効化はバッジダイアログを閉じた後まで遅延させる。
+      ..listenManual(awardFirstLaunchBadgeProvider, (_, next) {
+        next.whenOrNull(
+          data: (badge) {
+            if (badge != null) {
+              WidgetsBinding.instance.addPostFrameCallback((_) async {
+                if (!mounted) {
+                  return;
+                }
+                await BadgeAcquiredDialog.show(context, earnedBadge: badge);
+                if (!mounted) {
+                  return;
+                }
+                _activateDailyBonusIfNeeded();
+              });
+            } else {
+              _activateDailyBonusIfNeeded();
+            }
+          },
+          error: (_, _) {
+            _activateDailyBonusIfNeeded();
+          },
+        );
       });
+  }
+
+  /// ログインボーナスプロバイダーを有効化する（重複起動防止）
+  void _activateDailyBonusIfNeeded() {
+    if (_dailyBonusActivated) {
+      return;
+    }
+    _dailyBonusActivated = true;
+    ref.listenManual(awardDailyLoginBonusProvider, (_, _) {
+      // Providerの副作用のみを利用するため、何もしない
+    });
   }
 
   void _onFocusChanged() {

--- a/client/lib/ui/feature/settings/debug_screen.dart
+++ b/client/lib/ui/feature/settings/debug_screen.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:house_worker/data/repository/earned_badges_repository.dart';
 import 'package:house_worker/data/repository/login_bonus_granted_dates_repository.dart';
 import 'package:house_worker/data/repository/skip_clear_chat_confirmation_repository.dart';
 import 'package:house_worker/data/repository/viva_point_repository.dart';
@@ -34,6 +35,8 @@ class DebugScreen extends StatelessWidget {
           _ResetVPTile(),
           _SetVPToCustomValueTile(),
           _ResetLoginBonusTile(),
+          SectionHeader(title: 'バッジ設定'),
+          _ResetEarnedBadgesTile(),
           Divider(),
           SectionHeader(title: 'アカウント管理'),
           _LogoutTile(),
@@ -258,6 +261,25 @@ class _ResetLoginBonusTile extends ConsumerWidget {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('ログインボーナスの付与状態をリセットしました')),
+          );
+        }
+      },
+    );
+  }
+}
+
+class _ResetEarnedBadgesTile extends ConsumerWidget {
+  const _ResetEarnedBadgesTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      title: const Text('獲得済みバッジをリセット (獲得なしに戻す)'),
+      onTap: () async {
+        await ref.read(earnedBadgesRepositoryProvider.notifier).resetForDebug();
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('獲得済みバッジをリセットしました')),
           );
         }
       },

--- a/client/lib/ui/feature/stats/badge_acquired_dialog.dart
+++ b/client/lib/ui/feature/stats/badge_acquired_dialog.dart
@@ -38,7 +38,7 @@ class BadgeAcquiredDialog extends StatelessWidget {
       'おめでとう！',
       style: theme.textTheme.titleLarge?.copyWith(
         fontWeight: FontWeight.bold,
-        color: Colors.orange,
+        color: theme.colorScheme.tertiary,
       ),
     );
 

--- a/client/lib/ui/feature/stats/badge_acquired_dialog.dart
+++ b/client/lib/ui/feature/stats/badge_acquired_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/ui/component/app_badge_extension.dart';
+import 'package:house_worker/ui/component/app_badge_icon.dart';
 
 /// バッジ獲得ダイアログ
 class BadgeAcquiredDialog extends StatelessWidget {
@@ -26,10 +27,9 @@ class BadgeAcquiredDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final badgeIcon = Icon(
-      earnedBadge.badge.icon,
-      size: 64,
-      color: theme.colorScheme.primary,
+    final badgeIcon = AppBadgeIcon(
+      badge: earnedBadge.badge,
+      size: 88,
     );
 
     final congratsText = Text(

--- a/client/lib/ui/feature/stats/badge_acquired_dialog.dart
+++ b/client/lib/ui/feature/stats/badge_acquired_dialog.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:house_worker/data/model/earned_badge.dart';
+import 'package:house_worker/ui/component/app_badge_extension.dart';
+
+/// バッジ獲得ダイアログ
+class BadgeAcquiredDialog extends StatelessWidget {
+  const BadgeAcquiredDialog({
+    required this.earnedBadge,
+    super.key,
+  });
+
+  final EarnedBadge earnedBadge;
+
+  /// ダイアログを表示
+  static Future<void> show(
+    BuildContext context, {
+    required EarnedBadge earnedBadge,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (_) => BadgeAcquiredDialog(earnedBadge: earnedBadge),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final badgeIcon = Icon(
+      earnedBadge.badge.icon,
+      size: 64,
+      color: theme.colorScheme.primary,
+    );
+
+    final congratsText = Text(
+      'おめでとう！',
+      style: theme.textTheme.titleLarge?.copyWith(
+        fontWeight: FontWeight.bold,
+        color: Colors.orange,
+      ),
+    );
+
+    final description = Text(
+      'バッジを獲得しました',
+      style: theme.textTheme.bodyMedium,
+    );
+
+    final badgeTitle = Text(
+      earnedBadge.badge.displayName,
+      style: theme.textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.bold,
+      ),
+      textAlign: TextAlign.center,
+    );
+
+    final closeButton = SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: () => Navigator.of(context).pop(),
+        child: const Text('閉じる'),
+      ),
+    );
+
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            badgeIcon,
+            const SizedBox(height: 16),
+            congratsText,
+            const SizedBox(height: 8),
+            description,
+            const SizedBox(height: 12),
+            badgeTitle,
+            const SizedBox(height: 24),
+            closeButton,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/lib/ui/feature/stats/badge_acquired_dialog.dart
+++ b/client/lib/ui/feature/stats/badge_acquired_dialog.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/ui/component/app_badge_extension.dart';
 import 'package:house_worker/ui/component/app_badge_icon.dart';
+import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
+import 'package:house_worker/ui/feature/stats/user_statistics_screen.dart';
 
 /// バッジ獲得ダイアログ
 class BadgeAcquiredDialog extends StatelessWidget {
@@ -59,9 +61,22 @@ class BadgeAcquiredDialog extends StatelessWidget {
       textAlign: TextAlign.center,
     );
 
-    final closeButton = SizedBox(
+    final checkAllBadgesButton = SizedBox(
       width: double.infinity,
       child: ElevatedButton(
+        onPressed: () {
+          HapticFeedbackHelper.lightImpact();
+          Navigator.of(context)
+            ..pop()
+            ..push(UserStatisticsScreen.route());
+        },
+        child: const Text('全てのバッジを確認する'),
+      ),
+    );
+
+    final closeButton = SizedBox(
+      width: double.infinity,
+      child: TextButton(
         onPressed: () => Navigator.of(context).pop(),
         child: const Text('閉じる'),
       ),
@@ -86,6 +101,8 @@ class BadgeAcquiredDialog extends StatelessWidget {
             const SizedBox(height: 8),
             badgeDescription,
             const SizedBox(height: 24),
+            checkAllBadgesButton,
+            const SizedBox(height: 8),
             closeButton,
           ],
         ),

--- a/client/lib/ui/feature/stats/badge_detail_dialog.dart
+++ b/client/lib/ui/feature/stats/badge_detail_dialog.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/ui/component/app_badge_extension.dart';
 
-/// バッジ獲得ダイアログ
-class BadgeAcquiredDialog extends StatelessWidget {
-  const BadgeAcquiredDialog({
+/// バッジ詳細ダイアログ
+class BadgeDetailDialog extends StatelessWidget {
+  const BadgeDetailDialog({
     required this.earnedBadge,
     super.key,
   });
@@ -18,7 +18,7 @@ class BadgeAcquiredDialog extends StatelessWidget {
   }) {
     return showDialog<void>(
       context: context,
-      builder: (_) => BadgeAcquiredDialog(earnedBadge: earnedBadge),
+      builder: (_) => BadgeDetailDialog(earnedBadge: earnedBadge),
     );
   }
 
@@ -32,19 +32,6 @@ class BadgeAcquiredDialog extends StatelessWidget {
       color: theme.colorScheme.primary,
     );
 
-    final congratsText = Text(
-      'おめでとう！',
-      style: theme.textTheme.titleLarge?.copyWith(
-        fontWeight: FontWeight.bold,
-        color: Colors.orange,
-      ),
-    );
-
-    final description = Text(
-      'バッジを獲得しました',
-      style: theme.textTheme.bodyMedium,
-    );
-
     final badgeTitle = Text(
       earnedBadge.badge.displayName,
       style: theme.textTheme.titleMedium?.copyWith(
@@ -53,9 +40,18 @@ class BadgeAcquiredDialog extends StatelessWidget {
       textAlign: TextAlign.center,
     );
 
-    final badgeDescription = Text(
+    final description = Text(
       earnedBadge.badge.description,
       style: theme.textTheme.bodyMedium,
+      textAlign: TextAlign.center,
+    );
+
+    final earnedAt = earnedBadge.earnedAt;
+    final dateLabel = Text(
+      '獲得日: ${earnedAt.year}/${earnedAt.month.toString().padLeft(2, '0')}/${earnedAt.day.toString().padLeft(2, '0')}',
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
       textAlign: TextAlign.center,
     );
 
@@ -78,13 +74,11 @@ class BadgeAcquiredDialog extends StatelessWidget {
           children: [
             badgeIcon,
             const SizedBox(height: 16),
-            congratsText,
-            const SizedBox(height: 8),
-            description,
-            const SizedBox(height: 12),
             badgeTitle,
-            const SizedBox(height: 8),
-            badgeDescription,
+            const SizedBox(height: 12),
+            description,
+            const SizedBox(height: 16),
+            dateLabel,
             const SizedBox(height: 24),
             closeButton,
           ],

--- a/client/lib/ui/feature/stats/badge_detail_dialog.dart
+++ b/client/lib/ui/feature/stats/badge_detail_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/ui/component/app_badge_extension.dart';
+import 'package:house_worker/ui/component/app_badge_icon.dart';
 
 /// バッジ詳細ダイアログ
 class BadgeDetailDialog extends StatelessWidget {
@@ -26,10 +27,9 @@ class BadgeDetailDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final badgeIcon = Icon(
-      earnedBadge.badge.icon,
-      size: 64,
-      color: theme.colorScheme.primary,
+    final badgeIcon = AppBadgeIcon(
+      badge: earnedBadge.badge,
+      size: 88,
     );
 
     final badgeTitle = Text(

--- a/client/lib/ui/feature/stats/user_statistics_screen.dart
+++ b/client/lib/ui/feature/stats/user_statistics_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/data/repository/earned_badges_repository.dart';
 import 'package:house_worker/ui/component/app_badge_extension.dart';
+import 'package:house_worker/ui/component/app_badge_icon.dart';
 import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cavivara_portrait.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
@@ -194,10 +195,9 @@ class _EarnedBadgeTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final badgeIcon = Icon(
-      earnedBadge.badge.icon,
-      size: 48,
-      color: theme.colorScheme.primary,
+    final badgeIcon = AppBadgeIcon(
+      badge: earnedBadge.badge,
+      size: 64,
     );
 
     final title = Text(
@@ -219,26 +219,23 @@ class _EarnedBadgeTile extends StatelessWidget {
       textAlign: TextAlign.center,
     );
 
-    return Card(
-      elevation: 2,
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: () {
-          HapticFeedbackHelper.lightImpact();
-          BadgeDetailDialog.show(context, earnedBadge: earnedBadge);
-        },
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              badgeIcon,
-              const SizedBox(height: 8),
-              title,
-              const SizedBox(height: 4),
-              dateLabel,
-            ],
-          ),
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: () {
+        HapticFeedbackHelper.lightImpact();
+        BadgeDetailDialog.show(context, earnedBadge: earnedBadge);
+      },
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            badgeIcon,
+            const SizedBox(height: 8),
+            title,
+            const SizedBox(height: 4),
+            dateLabel,
+          ],
         ),
       ),
     );

--- a/client/lib/ui/feature/stats/user_statistics_screen.dart
+++ b/client/lib/ui/feature/stats/user_statistics_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:house_worker/data/model/earned_badge.dart';
+import 'package:house_worker/data/repository/earned_badges_repository.dart';
+import 'package:house_worker/ui/component/app_badge_extension.dart';
 import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cavivara_portrait.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
@@ -67,6 +70,8 @@ class UserStatisticsScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 32),
             _buildSupporterSection(context, supporterState),
+            const SizedBox(height: 48),
+            const _EarnedBadgeSection(),
           ],
         ),
       ),
@@ -123,6 +128,111 @@ class UserStatisticsScreen extends ConsumerWidget {
         child: CircularProgressIndicator(),
       ),
       error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+/// 獲得済みバッジ一覧セクション
+class _EarnedBadgeSection extends ConsumerWidget {
+  const _EarnedBadgeSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final earnedBadgesAsync = ref.watch(earnedBadgesRepositoryProvider);
+
+    return earnedBadgesAsync.when(
+      data: (badges) {
+        if (badges.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        final sectionTitle = Text(
+          '獲得済みバッジ',
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        );
+
+        // タイルレイアウト（2列グリッド、新しい順に左上から配置）
+        final grid = GridView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2,
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            childAspectRatio: 0.85,
+          ),
+          itemCount: badges.length,
+          itemBuilder: (context, index) =>
+              _EarnedBadgeTile(earnedBadge: badges[index]),
+        );
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            sectionTitle,
+            const SizedBox(height: 16),
+            grid,
+          ],
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+/// 獲得済みバッジのタイル
+class _EarnedBadgeTile extends StatelessWidget {
+  const _EarnedBadgeTile({required this.earnedBadge});
+
+  final EarnedBadge earnedBadge;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final badgeIcon = Icon(
+      earnedBadge.badge.icon,
+      size: 48,
+      color: theme.colorScheme.primary,
+    );
+
+    final title = Text(
+      earnedBadge.badge.displayName,
+      style: theme.textTheme.bodySmall?.copyWith(
+        fontWeight: FontWeight.bold,
+      ),
+      textAlign: TextAlign.center,
+      maxLines: 3,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    final earnedAt = earnedBadge.earnedAt;
+    final dateLabel = Text(
+      '${earnedAt.year}/${earnedAt.month.toString().padLeft(2, '0')}/${earnedAt.day.toString().padLeft(2, '0')}',
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      textAlign: TextAlign.center,
+    );
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            badgeIcon,
+            const SizedBox(height: 8),
+            title,
+            const SizedBox(height: 4),
+            dateLabel,
+          ],
+        ),
+      ),
     );
   }
 }

--- a/client/lib/ui/feature/stats/user_statistics_screen.dart
+++ b/client/lib/ui/feature/stats/user_statistics_screen.dart
@@ -13,6 +13,7 @@ import 'package:house_worker/ui/feature/home/home_screen.dart';
 import 'package:house_worker/ui/feature/settings/settings_screen.dart';
 import 'package:house_worker/ui/feature/settings/support_cavivara_presenter.dart';
 import 'package:house_worker/ui/feature/settings/support_cavivara_screen.dart';
+import 'package:house_worker/ui/feature/stats/badge_detail_dialog.dart';
 
 class UserStatisticsScreen extends ConsumerWidget {
   const UserStatisticsScreen({super.key});
@@ -220,17 +221,24 @@ class _EarnedBadgeTile extends StatelessWidget {
 
     return Card(
       elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            badgeIcon,
-            const SizedBox(height: 8),
-            title,
-            const SizedBox(height: 4),
-            dateLabel,
-          ],
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () {
+          HapticFeedbackHelper.lightImpact();
+          BadgeDetailDialog.show(context, earnedBadge: earnedBadge);
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              badgeIcon,
+              const SizedBox(height: 8),
+              title,
+              const SizedBox(height: 4),
+              dateLabel,
+            ],
+          ),
         ),
       ),
     );

--- a/client/test/data/repository/earned_badges_repository_test.dart
+++ b/client/test/data/repository/earned_badges_repository_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/app_badge.dart';
+import 'package:house_worker/data/model/earned_badge.dart';
+import 'package:house_worker/data/repository/earned_badges_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+void main() {
+  group('EarnedBadgesRepository', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    group('初期状態', () {
+      test('初回起動時は空リストを返すこと', () async {
+        final badges = await container.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+
+        expect(badges, isEmpty);
+      });
+    });
+
+    group('バッジの追加', () {
+      test('バッジを追加できること', () async {
+        final notifier = container.read(
+          earnedBadgesRepositoryProvider.notifier,
+        );
+
+        final badge = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+
+        await notifier.add(badge);
+
+        final badges = await container.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+
+        expect(badges.length, 1);
+        expect(badges.first.badge, AppBadge.firstLaunch);
+      });
+
+      test('追加したバッジが永続化されること', () async {
+        final notifier = container.read(
+          earnedBadgesRepositoryProvider.notifier,
+        );
+
+        final badge = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+
+        await notifier.add(badge);
+
+        // 新しいコンテナで再読み込みして永続化を確認
+        final newContainer = ProviderContainer();
+        addTearDown(newContainer.dispose);
+
+        final reloadedBadges = await newContainer.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+
+        expect(reloadedBadges.length, 1);
+        expect(reloadedBadges.first.badge, AppBadge.firstLaunch);
+      });
+
+      test('新しいバッジが先頭に追加されること', () async {
+        final notifier = container.read(
+          earnedBadgesRepositoryProvider.notifier,
+        );
+
+        final badge1 = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 10),
+        );
+
+        final badge2 = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+
+        await notifier.add(badge1);
+        await notifier.add(badge2);
+
+        final badges = await container.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+
+        expect(badges.length, 2);
+        // 最新が先頭
+        expect(badges.first.earnedAt, DateTime(2026, 6, 27, 12));
+        expect(badges.last.earnedAt, DateTime(2026, 6, 27, 10));
+      });
+    });
+  });
+}

--- a/client/test/data/repository/earned_badges_repository_test.dart
+++ b/client/test/data/repository/earned_badges_repository_test.dart
@@ -105,5 +105,51 @@ void main() {
         expect(badges.last.earnedAt, DateTime(2026, 6, 27, 10));
       });
     });
+
+    group('バッジのリセット', () {
+      test('獲得済みバッジをリセットできること', () async {
+        final notifier = container.read(
+          earnedBadgesRepositoryProvider.notifier,
+        );
+
+        final badge = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+
+        await notifier.add(badge);
+        await notifier.resetForDebug();
+
+        final badges = await container.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+
+        expect(badges, isEmpty);
+      });
+
+      test('リセット後は永続化された状態も空になること', () async {
+        final notifier = container.read(
+          earnedBadgesRepositoryProvider.notifier,
+        );
+
+        final badge = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+
+        await notifier.add(badge);
+        await notifier.resetForDebug();
+
+        // 新しいコンテナで再読み込みして永続化状態を確認
+        final newContainer = ProviderContainer();
+        addTearDown(newContainer.dispose);
+
+        final reloadedBadges = await newContainer.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+
+        expect(reloadedBadges, isEmpty);
+      });
+    });
   });
 }

--- a/client/test/ui/feature/home/home_presenter_test.dart
+++ b/client/test/ui/feature/home/home_presenter_test.dart
@@ -1,15 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:house_worker/data/model/ai_response.dart';
+import 'package:house_worker/data/model/app_badge.dart';
 import 'package:house_worker/data/model/cavivara_profile.dart';
 import 'package:house_worker/data/model/chat_message.dart';
+import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/model/send_message_exception.dart';
+import 'package:house_worker/data/repository/earned_badges_repository.dart';
 import 'package:house_worker/data/service/ai_chat_service.dart';
 import 'package:house_worker/data/service/cavivara_profile_service.dart';
 import 'package:house_worker/data/service/preference_service.dart';
 import 'package:house_worker/ui/feature/home/home_presenter.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 class MockAiChatService extends Mock implements AiChatService {}
 
@@ -519,6 +525,86 @@ void main() {
         // サジェストがクリアされていることを確認
         final suggestions = container.read(suggestedRepliesProvider);
         expect(suggestions, isEmpty);
+      });
+    });
+  });
+
+  group('Home Presenter - AwardFirstLaunchBadge', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    group('awardFirstLaunchBadgeProvider', () {
+      test('初回起動バッジが未付与の場合、バッジを付与して返すこと', () async {
+        final earnedBadge = await container.read(
+          awardFirstLaunchBadgeProvider.future,
+        );
+
+        expect(earnedBadge, isNotNull);
+        expect(earnedBadge!.badge, AppBadge.firstLaunch);
+      });
+
+      test('初回起動バッジが未付与の場合、リポジトリに追加されること', () async {
+        await container.read(awardFirstLaunchBadgeProvider.future);
+
+        final badges = await container.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+        expect(badges.length, 1);
+        expect(badges.first.badge, AppBadge.firstLaunch);
+      });
+
+      test('初回起動バッジがすでに付与済みの場合、null を返すこと', () async {
+        // 事前にバッジを追加
+        final badge = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+        await container.read(earnedBadgesRepositoryProvider.notifier).add(
+          badge,
+        );
+
+        // 別のコンテナで確認（同一コンテナではキャッシュされるため）
+        final container2 = ProviderContainer();
+        addTearDown(container2.dispose);
+
+        final earnedBadge = await container2.read(
+          awardFirstLaunchBadgeProvider.future,
+        );
+
+        expect(earnedBadge, isNull);
+      });
+
+      test('初回起動バッジがすでに付与済みの場合、リポジトリへの追加が行われないこと', () async {
+        // 事前にバッジを追加
+        final badge = EarnedBadge(
+          badge: AppBadge.firstLaunch,
+          earnedAt: DateTime(2026, 6, 27, 12),
+        );
+        await container.read(earnedBadgesRepositoryProvider.notifier).add(
+          badge,
+        );
+
+        // 別のコンテナで awardFirstLaunchBadgeProvider を呼び出す
+        final container2 = ProviderContainer();
+        addTearDown(container2.dispose);
+
+        await container2.read(awardFirstLaunchBadgeProvider.future);
+
+        final badges = await container2.read(
+          earnedBadgesRepositoryProvider.future,
+        );
+        // 重複追加されず、元の1件のみ
+        expect(badges.length, 1);
       });
     });
   });


### PR DESCRIPTION
## 概要

- アプリ初回起動時に「カヴィヴァラの世界に足を踏み入れる」バッジを自動付与
- バッジ獲得時にダイアログ表示
- 業績画面の下部に獲得済みバッジ一覧（2列タイル、新しい順）
- バッジダイアログ → VP取得通知の順に表示

Closes #415

Generated with [Claude Code](https://claude.ai/code)