### PR TITLE
feat(settings): 設定画面に Install ID 表示とデバッグ機能の Remote Config 制御を追加

### DIFF
--- a/client/lib/data/definition/app_feature.dart
+++ b/client/lib/data/definition/app_feature.dart
@@ -9,6 +9,15 @@ final bool showCustomAppBanner =
 
 final useFirebaseEmulator = flavor == Flavor.emulator;
 
+/// デバッグ機能の表示可否を Remote Config で制御するか否か
+///
+/// Production-Release（一般公開アプリのリリースビルド）の実行 Suite のみ Remote Config で制御し、
+/// それ以外の Suite では常に表示する。
+/// `kReleaseMode` を先に評価することで、`FLUTTER_APP_FLAVOR` 未指定のテスト環境では
+/// 例外を投げる `flavor` の参照を回避する。
+final bool useRemoteConfigForShowDebugFeature =
+    kReleaseMode && flavor == Flavor.prod;
+
 /// エラーの詳細内容を UI に表示するか否か
 ///
 /// 一般公開アプリのリリースビルドでは、内部的なエラー詳細をユーザーに見せないため表示しない。

--- a/client/lib/data/service/firebase_installations_service.dart
+++ b/client/lib/data/service/firebase_installations_service.dart
@@ -1,0 +1,10 @@
+import 'package:firebase_app_installations/firebase_app_installations.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'firebase_installations_service.g.dart';
+
+/// Firebase Installation ID (FID) を取得する
+@riverpod
+Future<String> firebaseInstallationId(Ref ref) {
+  return FirebaseInstallations.instance.getId();
+}

--- a/client/lib/data/service/remote_config_service.dart
+++ b/client/lib/data/service/remote_config_service.dart
@@ -28,3 +28,12 @@ int? minimumBuildNumber(Ref ref) {
 
   return minimumBuildNumber;
 }
+
+/// Production-Release Suite でデバッグ機能を表示するか否か
+///
+/// デフォルト値は false。`getBool` は未設定時に false を返すため、
+/// Remote Config に値が設定されていない場合はデバッグ機能を表示しない。
+@riverpod
+bool showDebugFeatureOnProdRelease(Ref ref) {
+  return FirebaseRemoteConfig.instance.getBool('showDebugFeatureOnProdRelease');
+}

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:house_worker/data/definition/app_definition.dart';
@@ -9,6 +10,7 @@ import 'package:house_worker/data/model/sign_in_result.dart';
 import 'package:house_worker/data/model/user_profile.dart';
 import 'package:house_worker/data/service/app_info_service.dart';
 import 'package:house_worker/data/service/auth_service.dart';
+import 'package:house_worker/data/service/firebase_installations_service.dart';
 import 'package:house_worker/data/service/remote_config_service.dart';
 import 'package:house_worker/ui/component/color.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
@@ -413,17 +415,20 @@ class _AppVersionTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final appVersionAsync = ref.watch(currentAppVersionProvider);
 
+    // バージョン名と Install ID で共通の Typography を使用する。
+    final labelStyle = Theme.of(
+      context,
+    ).textTheme.labelLarge!.copyWith(color: Theme.of(context).dividerColor);
+
     final versionString = appVersionAsync.when(
       data: (appVersion) =>
           'バージョン: ${appVersion.version} (${appVersion.buildNumber})',
       loading: () => 'バージョン: n.n.n (nnn)',
       error: (_, _) => 'バージョン情報を取得できませんでした',
     );
-    final versionText = Text(
-      versionString,
-      style: Theme.of(
-        context,
-      ).textTheme.labelLarge!.copyWith(color: Theme.of(context).dividerColor),
+    final versionText = Skeletonizer(
+      enabled: appVersionAsync.isLoading,
+      child: Text(versionString, style: labelStyle),
     );
 
     return Center(
@@ -432,13 +437,89 @@ class _AppVersionTile extends ConsumerWidget {
         bottom: false,
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Skeletonizer(
-            enabled: appVersionAsync.isLoading,
-            child: versionText,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              versionText,
+              const SizedBox(height: 8),
+              _InstallationId(labelStyle: labelStyle),
+            ],
           ),
         ),
       ),
     );
+  }
+}
+
+/// Firebase Installation ID を表示し、コピーボタンを提供するウィジェット
+class _InstallationId extends ConsumerWidget {
+  const _InstallationId({required this.labelStyle});
+
+  final TextStyle labelStyle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final installationIdAsync = ref.watch(firebaseInstallationIdProvider);
+
+    final installationId = installationIdAsync.whenOrNull(data: (id) => id);
+    final installationIdString = installationIdAsync.when(
+      data: (id) => 'Install ID: $id',
+      loading: () => 'Install ID: nnnnnnnnnnnnnnnnnnnnnn',
+      error: (_, _) => 'Install ID を取得できませんでした',
+    );
+    final installationIdText = Skeletonizer(
+      enabled: installationIdAsync.isLoading,
+      child: Text(
+        installationIdString,
+        style: labelStyle,
+        textAlign: TextAlign.center,
+      ),
+    );
+
+    if (installationId == null) {
+      return installationIdText;
+    }
+
+    // コピーボタンの横幅。左側にも同じ幅の余白を設けて、テキストを中央に見せる。
+    const copyButtonSize = 32.0;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // 右側のコピーボタンと釣り合いを取り、テキストを中央に配置する。
+        const SizedBox(width: copyButtonSize),
+        Flexible(child: installationIdText),
+        SizedBox(
+          width: copyButtonSize,
+          child: IconButton(
+            icon: const Icon(Icons.copy, size: 16),
+            color: labelStyle.color,
+            visualDensity: VisualDensity.compact,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            tooltip: 'Install ID をコピー',
+            onPressed: () => _copyInstallationId(context, installationId),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _copyInstallationId(
+    BuildContext context,
+    String installationId,
+  ) async {
+    HapticFeedbackHelper.lightImpact();
+
+    await Clipboard.setData(ClipboardData(text: installationId));
+
+    if (!context.mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Install ID をコピーしました')));
   }
 }
 

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -4,10 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:house_worker/data/definition/app_definition.dart';
+import 'package:house_worker/data/definition/app_feature.dart';
 import 'package:house_worker/data/model/sign_in_result.dart';
 import 'package:house_worker/data/model/user_profile.dart';
 import 'package:house_worker/data/service/app_info_service.dart';
 import 'package:house_worker/data/service/auth_service.dart';
+import 'package:house_worker/data/service/remote_config_service.dart';
 import 'package:house_worker/ui/component/color.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
 import 'package:house_worker/ui/component/supporter_title_extension.dart';
@@ -42,6 +44,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget build(BuildContext context) {
     final userProfileAsync = ref.watch(currentUserProfileProvider);
 
+    // Production-Release Suite では Remote Config でデバッグ機能の表示可否を制御する。
+    // それ以外の Suite では常に表示する。
+    final showDebugFeature =
+        !useRemoteConfigForShowDebugFeature ||
+        ref.watch(showDebugFeatureOnProdReleaseProvider);
+
     return Scaffold(
       appBar: AppBar(title: const Text('設定')),
       body: userProfileAsync.when(
@@ -64,8 +72,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               _buildPrivacyPolicyTile(context),
               _buildLicenseTile(context),
               const Divider(),
-              const SectionHeader(title: 'デバッグ'),
-              _buildDebugTile(context),
+              if (showDebugFeature) ...[
+                const SectionHeader(title: 'デバッグ'),
+                _buildDebugTile(context),
+              ],
               const _AppVersionTile(),
             ],
           );

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1089,10 +1089,10 @@ packages:
     dependency: "direct main"
     description:
       name: purchases_flutter
-      sha256: "8b70ab671adca2cd067492e24f2d1b342e948c7dace35bf0baa6d3c8901674e9"
+      sha256: "15c354a07aeabe1cda32fff84ce3e1d7e6645725cb7f9fca7c0738982d1b499d"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.0"
+    version: "10.4.1"
   record_use:
     dependency: transitive
     description:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -441,6 +441,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.5"
+  firebase_app_installations:
+    dependency: "direct main"
+    description:
+      name: firebase_app_installations
+      sha256: "68240d60d1f2cced8d21bafb6917b181aa2ba6fa0f87acd7039ca6e6cd13e413"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2+4"
+  firebase_app_installations_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_app_installations_platform_interface
+      sha256: "1e5a834454b2afdd0913103bcf0d63056fde67c6e995445de1098a03c89d08f9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4+72"
+  firebase_app_installations_web:
+    dependency: transitive
+    description:
+      name: firebase_app_installations_web
+      sha256: cf227945bb3fc02d53b9cfd267c76399204dc1e9830e1461f30524257e4afb26
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.7+9"
   firebase_auth:
     dependency: "direct main"
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   firebase_ai: 3.13.1
   firebase_analytics: 12.4.3
   firebase_app_check: 0.4.5
+  firebase_app_installations: 0.4.2+4
   firebase_auth: 6.5.4
   firebase_core: 4.11.0
   firebase_crashlytics: 5.2.4

--- a/client/test/ui/feature/settings/settings_screen_test.dart
+++ b/client/test/ui/feature/settings/settings_screen_test.dart
@@ -258,11 +258,13 @@ void main() {
     );
 
     testWidgets(
-      'showDebugFeatureOnProdReleaseがfalseでも、Production-Release以外ではデバッグ機能が表示されること',
+      'showDebugFeatureOnProdReleaseがfalseでも、'
+      'Production-Release以外ではデバッグ機能が表示されること',
       (tester) async {
         // Arrange
-        // useRemoteConfigForShowDebugFeatureはkReleaseMode && flavor == Flavor.prodで
-        // 決まり、flutter testの実行はReleaseモードではないため常にfalseになる。
+        // useRemoteConfigForShowDebugFeatureは
+        // kReleaseMode && flavor == Flavor.prodで決まり、
+        // flutter testの実行はReleaseモードではないため常にfalseになる。
         // そのため、showDebugFeatureOnProdReleaseの値に関わらずデバッグ機能は表示される。
         container.dispose();
         container = ProviderContainer(

--- a/client/test/ui/feature/settings/settings_screen_test.dart
+++ b/client/test/ui/feature/settings/settings_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:house_worker/data/model/product_package.dart';
 import 'package:house_worker/data/model/user_profile.dart';
 import 'package:house_worker/data/repository/viva_point_repository.dart';
 import 'package:house_worker/data/service/auth_service.dart';
+import 'package:house_worker/data/service/firebase_installations_service.dart';
 import 'package:house_worker/data/service/in_app_purchase_service.dart';
 import 'package:house_worker/ui/feature/settings/settings_screen.dart';
 import 'package:house_worker/ui/feature/settings/support_cavivara_screen.dart';
@@ -48,6 +49,12 @@ void main() {
           // InAppPurchaseのパッケージリストをモック化（空リストを返す）
           currentPackagesProvider.overrideWith(
             (ref) => Future.value(<ProductPackage>[]),
+          ),
+          // Firebase Installation ID は Firebase 未初期化の環境ではエラーになるため、
+          // Skeletonizer のシマーが止まらず pumpAndSettle がタイムアウトする。
+          // そのためモック化する。
+          firebaseInstallationIdProvider.overrideWith(
+            (ref) => Future.value('test-installation-id'),
           ),
         ],
       );
@@ -99,6 +106,12 @@ void main() {
           // InAppPurchaseのパッケージリストをモック化（空リストを返す）
           currentPackagesProvider.overrideWith(
             (ref) => Future.value(<ProductPackage>[]),
+          ),
+          // Firebase Installation ID は Firebase 未初期化の環境ではエラーになるため、
+          // Skeletonizer のシマーが止まらず pumpAndSettle がタイムアウトする。
+          // そのためモック化する。
+          firebaseInstallationIdProvider.overrideWith(
+            (ref) => Future.value('test-installation-id'),
           ),
         ],
       );

--- a/client/test/ui/feature/settings/settings_screen_test.dart
+++ b/client/test/ui/feature/settings/settings_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:house_worker/data/model/preference_key.dart';
@@ -8,6 +9,7 @@ import 'package:house_worker/data/repository/viva_point_repository.dart';
 import 'package:house_worker/data/service/auth_service.dart';
 import 'package:house_worker/data/service/firebase_installations_service.dart';
 import 'package:house_worker/data/service/in_app_purchase_service.dart';
+import 'package:house_worker/data/service/remote_config_service.dart';
 import 'package:house_worker/ui/feature/settings/settings_screen.dart';
 import 'package:house_worker/ui/feature/settings/support_cavivara_screen.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -175,5 +177,130 @@ void main() {
       // 駆け出し称号が表示されていること
       expect(find.textContaining('駆け出しヴィヴァサポーター'), findsOneWidget);
     });
+
+    testWidgets(
+      'Install IDが表示され、コピーボタンをタップするとクリップボードにコピーされてSnackBarが表示されること',
+      (tester) async {
+        // Arrange
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: SettingsScreen(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final copyButtonFinder = find.byTooltip('Install ID をコピー');
+        await tester.scrollUntilVisible(copyButtonFinder, 200);
+        await tester.pumpAndSettle();
+
+        // Assert
+        // Install IDが表示されていること
+        expect(find.text('Install ID: test-installation-id'), findsOneWidget);
+
+        // Act - コピーボタンをタップ
+        await tester.tap(copyButtonFinder);
+        await tester.pumpAndSettle();
+
+        // Assert
+        // クリップボードにコピーされていること
+        final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+        expect(clipboardData?.text, 'test-installation-id');
+
+        // コピーした旨のSnackBarが表示されていること
+        expect(find.text('Install ID をコピーしました'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'showDebugFeatureOnProdReleaseがtrueの場合、デバッグ機能が表示されること',
+      (tester) async {
+        // Arrange
+        container.dispose();
+        container = ProviderContainer(
+          overrides: [
+            currentUserProfileProvider.overrideWith((ref) {
+              return Stream.value(
+                const UserProfileWithGoogleAccount(
+                  id: 'test-id',
+                  displayName: 'Test User',
+                  email: 'test@example.com',
+                  photoUrl: null,
+                ),
+              );
+            }),
+            currentPackagesProvider.overrideWith(
+              (ref) => Future.value(<ProductPackage>[]),
+            ),
+            firebaseInstallationIdProvider.overrideWith(
+              (ref) => Future.value('test-installation-id'),
+            ),
+            showDebugFeatureOnProdReleaseProvider.overrideWith((ref) => true),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: SettingsScreen(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        await tester.scrollUntilVisible(find.text('デバッグ画面'), 200);
+        expect(find.text('デバッグ画面'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'showDebugFeatureOnProdReleaseがfalseでも、Production-Release以外ではデバッグ機能が表示されること',
+      (tester) async {
+        // Arrange
+        // useRemoteConfigForShowDebugFeatureはkReleaseMode && flavor == Flavor.prodで
+        // 決まり、flutter testの実行はReleaseモードではないため常にfalseになる。
+        // そのため、showDebugFeatureOnProdReleaseの値に関わらずデバッグ機能は表示される。
+        container.dispose();
+        container = ProviderContainer(
+          overrides: [
+            currentUserProfileProvider.overrideWith((ref) {
+              return Stream.value(
+                const UserProfileWithGoogleAccount(
+                  id: 'test-id',
+                  displayName: 'Test User',
+                  email: 'test@example.com',
+                  photoUrl: null,
+                ),
+              );
+            }),
+            currentPackagesProvider.overrideWith(
+              (ref) => Future.value(<ProductPackage>[]),
+            ),
+            firebaseInstallationIdProvider.overrideWith(
+              (ref) => Future.value('test-installation-id'),
+            ),
+            showDebugFeatureOnProdReleaseProvider.overrideWith((ref) => false),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: SettingsScreen(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert
+        await tester.scrollUntilVisible(find.text('デバッグ画面'), 200);
+        expect(find.text('デバッグ画面'), findsOneWidget);
+      },
+    );
   });
 }

--- a/client/test/ui/feature/settings/settings_screen_test.dart
+++ b/client/test/ui/feature/settings/settings_screen_test.dart
@@ -21,7 +21,29 @@ void main() {
   group('SettingsScreen - 称号表示機能', () {
     late ProviderContainer container;
 
+    // Clipboard は実プラットフォームチャネルを経由するため、testWidgets の
+    // fake-async ゾーン内では応答が返らず await Clipboard.setData / getData が
+    // 永久にハングする。そのためインメモリのモックハンドラを登録する。
+    Object? clipboardContents;
+
     setUp(() {
+      final binding = TestWidgetsFlutterBinding.ensureInitialized();
+      clipboardContents = null;
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (methodCall) async {
+          switch (methodCall.method) {
+            case 'Clipboard.setData':
+              clipboardContents = methodCall.arguments;
+              return null;
+            case 'Clipboard.getData':
+              return clipboardContents;
+            default:
+              return null;
+          }
+        },
+      );
+
       // _AppVersionTile が参照する currentAppVersionProvider は
       // PackageInfo.fromPlatform() を待つため、モックしないと
       // Skeletonizer のシマーが永久に動き pumpAndSettle がタイムアウトする。
@@ -63,6 +85,8 @@ void main() {
     });
 
     tearDown(() {
+      TestWidgetsFlutterBinding.ensureInitialized().defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
       container.dispose();
     });
 
@@ -211,6 +235,10 @@ void main() {
 
         // コピーした旨のSnackBarが表示されていること
         expect(find.text('Install ID をコピーしました'), findsOneWidget);
+
+        // SnackBar の自動非表示タイマーが残っているとテスト終了時に
+        // pending timer として検出されるため、時間を進めて解消する。
+        await tester.pumpAndSettle(const Duration(seconds: 5));
       },
     );
 


### PR DESCRIPTION
## 概要

設定画面に関する2つの機能を追加しました。

### 1. Firebase Installation ID の表示
- 設定画面のバージョン名の下に、バージョン名と同じ Typography で Firebase Installation ID を `Install ID: xxxx` の形式で表示します。
- テキストの右側にコピーボタンを配置し、タップするとクリップボードに ID をコピーして、コピーした旨の SnackBar を表示します。
- コピーボタンと釣り合う余白を左側にも設けることで、テキストを中央寄せで表示しています。

### 2. Production-Release でのデバッグ機能の表示制御
- Production-Release の実行 Suite では、Firebase Remote Config の `showDebugFeatureOnProdRelease` が `true` の場合のみ、設定画面に「デバッグ」機能を表示します。
- Production-Release 以外の Suite では常に表示します。
- `showDebugFeatureOnProdRelease` のデフォルト値は `false` です（`getBool` が未設定時に `false` を返す挙動を利用）。

## 追加・修正ファイル

| ファイル | 内容 |
| --- | --- |
| `client/pubspec.yaml` / `pubspec.lock` | `firebase_app_installations` を依存に追加 |
| `client/lib/data/service/firebase_installations_service.dart` | Firebase Installation ID を取得する Riverpod プロバイダを新規追加 |
| `client/lib/data/service/remote_config_service.dart` | `showDebugFeatureOnProdRelease` プロバイダを追加 |
| `client/lib/data/definition/app_feature.dart` | `useRemoteConfigForShowDebugFeature` フラグを追加 |
| `client/lib/ui/feature/settings/settings_screen.dart` | Install ID 表示ウィジェットの追加、デバッグ機能の条件表示 |
| `client/test/ui/feature/settings/settings_screen_test.dart` | `firebaseInstallationIdProvider` のモックを追加 |

## Related Issue

<!-- 作業指示者へ: 関連する Issue 番号があれば記載してください（例: close #123） -->

## Screenshots & Demo

<!-- 作業指示者へ: Install ID 表示および Production-Release でのデバッグ機能の表示/非表示のスクリーンショット・デモを添付してください -->

## レビューで見て欲しいポイント

<!-- 作業指示者へ: 特にレビューしてほしい観点を記載してください -->

---

> [!NOTE]
> サンドボックス環境ではローカルソケットを開けないため `flutter test` を実行できていません。マージ前に `flutter test` の実行をお願いします。
