### PR TITLE
feat(auth): 利用規約・プライバシーポリシーへの同意導線を追加

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,39 +1,4 @@
 
-# list of languages for which language servers are started (LSP backend only); choose from:
-#   ada                 al                  angular             ansible             bash
-#   bsl                 clojure             cpp                 cpp_ccls            crystal
-#   csharp              csharp_omnisharp    cue                 dart                elixir
-#   elm                 erlang              fortran             fsharp              gdscript
-#   go                  groovy              haskell             haxe                hlsl
-#   html                java                json                julia               kotlin
-#   latex               lean4               lua                 luau                markdown
-#   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        php_phpantom        powershell
-#   python              python_jedi         python_pyrefly      python_ty           r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   scss                solidity            svelte              swift               systemverilog
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
-#   (This list may be outdated; generated with scripts/print_language_list.py;
-#   For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
-# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
-# Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
-#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
-#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
-#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
-#   - For Free Pascal/Lazarus, use pascal
-# Special requirements:
-#   Some languages require additional setup/installations.
-#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
-# When using multiple languages, the first language server that supports a given file will be used for that file.
-# The first language is the default language and the respective language server will be used as a fallback.
-# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
-languages:
-- dart
-
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
@@ -43,6 +8,13 @@ ignore_all_files_in_gitignore: true
 
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
 # Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
@@ -166,3 +138,38 @@ activation_command:
 # maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
 # must be a positive number.
 activation_command_timeout: 180.0
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                    al                     angular                ansible                bash
+#   bsl                    clojure                cpp                    cpp_ccls               crystal
+#   csharp                 csharp_omnisharp       cue                    dart                   elixir
+#   elm                    erlang                 fortran                fsharp                 gdscript
+#   go                     groovy                 haskell                haxe                   hlsl
+#   html                   java                   json                   julia                  kotlin
+#   latex                  lean4                  lua                    luau                   markdown
+#   matlab                 msl                    nix                    ocaml                  pascal
+#   perl                   php                    php_phpactor           php_phpantom           powershell
+#   python                 python_basedpyright    python_jedi            python_pyrefly         python_ty
+#   qml                    r                      rego                   ruby                   ruby_solargraph
+#   rust                   scala                  scss                   solidity               svelte
+#   swift                  systemverilog          terraform              toml                   typescript
+#   typescript_vts         vue                    yaml                   zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of the LanguageServerId enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- dart

--- a/client/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-hybrid-common.git",
       "state" : {
-        "revision" : "260f01b449cdd42ac655272448b10d095957ed7c",
-        "version" : "18.19.0"
+        "revision" : "a7ba6df1ac467f18ef9b80151c3911ba1de387f8",
+        "version" : "18.22.2"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "6fcd89a5d6db067081148f0436a7c55d54f36d21",
-        "version" : "5.80.2"
+        "revision" : "4b28e6817c746be6bb710f2bcc0a7e8d9f9e3afa",
+        "version" : "5.81.1"
       }
     },
     {

--- a/client/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-hybrid-common.git",
       "state" : {
-        "revision" : "260f01b449cdd42ac655272448b10d095957ed7c",
-        "version" : "18.19.0"
+        "revision" : "a7ba6df1ac467f18ef9b80151c3911ba1de387f8",
+        "version" : "18.22.2"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "6fcd89a5d6db067081148f0436a7c55d54f36d21",
-        "version" : "5.80.2"
+        "revision" : "4b28e6817c746be6bb710f2bcc0a7e8d9f9e3afa",
+        "version" : "5.81.1"
       }
     },
     {

--- a/client/lib/data/definition/app_definition.dart
+++ b/client/lib/data/definition/app_definition.dart
@@ -1,5 +1,13 @@
 const appStoreId = '000000000';
 
+/// 利用規約ページの URL
+const termsOfServiceUrl =
+    'https://tricolor-fright-c89.notion.site/3a935dfd37af805a85d2e826048770d2';
+
+/// プライバシーポリシーページの URL
+const privacyPolicyUrl =
+    'https://tricolor-fright-c89.notion.site/29e35dfd37af80059ab2eb1cf50e1058';
+
 const revenueCatProjectTestApiKey = String.fromEnvironment(
   'REVENUE_CAT_PROJECT_TEST_API_KEY',
 );

--- a/client/lib/ui/feature/auth/login_screen.dart
+++ b/client/lib/ui/feature/auth/login_screen.dart
@@ -55,14 +55,17 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     ];
 
     return Scaffold(
-      body: SafeArea(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            // 横向きなどで縦幅が足りない場合はスクロールできるようにしつつ、
-            // 縦幅に余裕がある場合は従来どおり中央に配置する。
-            return SingleChildScrollView(
-              child: ConstrainedBox(
-                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          // 横向きなどで縦幅が足りない場合はスクロールできるようにしつつ、
+          // 縦幅に余裕がある場合は従来どおり中央に配置する。
+          // スクロールビュー自体は画面全体に広げ、スクロール中はコンテンツが
+          // セーフエリア外にも描画されるようにする。静止時のコンテンツ位置は
+          // 内側の SafeArea で確保する。
+          return SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: SafeArea(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 32,
@@ -74,9 +77,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   ),
                 ),
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/client/lib/ui/feature/auth/login_screen.dart
+++ b/client/lib/ui/feature/auth/login_screen.dart
@@ -59,22 +59,23 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         builder: (context, constraints) {
           // 横向きなどで縦幅が足りない場合はスクロールできるようにしつつ、
           // 縦幅に余裕がある場合は従来どおり中央に配置する。
-          // スクロールビュー自体は画面全体に広げ、スクロール中はコンテンツが
-          // セーフエリア外にも描画されるようにする。静止時のコンテンツ位置は
-          // 内側の SafeArea で確保する。
+          // セーフエリア分の余白はスクロール内容側の余白に含めることで、
+          // スクロール中はコンテンツがセーフエリア外にも描画されるようにする。
+          final safeAreaPadding = MediaQuery.paddingOf(context);
+
           return SingleChildScrollView(
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: constraints.maxHeight),
-              child: SafeArea(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 32,
-                    vertical: 24,
-                  ),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: children,
-                  ),
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(
+                  32 + safeAreaPadding.left,
+                  24 + safeAreaPadding.top,
+                  32 + safeAreaPadding.right,
+                  24 + safeAreaPadding.bottom,
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: children,
                 ),
               ),
             ),

--- a/client/lib/ui/feature/auth/login_screen.dart
+++ b/client/lib/ui/feature/auth/login_screen.dart
@@ -161,14 +161,12 @@ class _AgreementTextState extends State<_AgreementText> {
 
   Future<void> _launch(String urlString) async {
     final url = Uri.parse(urlString);
-    if (await canLaunchUrl(url)) {
-      await launchUrl(url);
-    } else {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
-      }
+    final launched = await launchUrl(url);
+
+    if (!launched && mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
     }
   }
 }

--- a/client/lib/ui/feature/auth/login_screen.dart
+++ b/client/lib/ui/feature/auth/login_screen.dart
@@ -55,13 +55,27 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     ];
 
     return Scaffold(
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: children,
-          ),
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // 横向きなどで縦幅が足りない場合はスクロールできるようにしつつ、
+            // 縦幅に余裕がある場合は従来どおり中央に配置する。
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 32,
+                    vertical: 24,
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: children,
+                  ),
+                ),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/client/lib/ui/feature/auth/login_screen.dart
+++ b/client/lib/ui/feature/auth/login_screen.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:house_worker/data/definition/app_definition.dart';
 import 'package:house_worker/ui/component/cavivara_avatar.dart';
 import 'package:house_worker/ui/feature/auth/login_presenter.dart';
 import 'package:house_worker/ui/feature/home/home_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
@@ -47,13 +50,18 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       ),
       const SizedBox(height: 60),
       continueWithoutAccountButton,
+      const SizedBox(height: 32),
+      const _AgreementText(),
     ];
 
     return Scaffold(
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: children,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: children,
+          ),
         ),
       ),
     );
@@ -69,5 +77,81 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     await Navigator.of(context).pushReplacement(
       HomeScreen.route(),
     );
+  }
+}
+
+/// 「はじめる」をタップして利用を開始すると、利用規約とプライバシーポリシーに
+/// 同意したものとみなす旨を表示するウィジェット。
+///
+/// 「利用規約」「プライバシーポリシー」の文言はそれぞれのページへのリンクになっている。
+class _AgreementText extends StatefulWidget {
+  const _AgreementText();
+
+  @override
+  State<_AgreementText> createState() => _AgreementTextState();
+}
+
+class _AgreementTextState extends State<_AgreementText> {
+  final _termsOfServiceRecognizer = TapGestureRecognizer();
+  final _privacyPolicyRecognizer = TapGestureRecognizer();
+
+  @override
+  void initState() {
+    super.initState();
+    _termsOfServiceRecognizer.onTap = () => _launch(termsOfServiceUrl);
+    _privacyPolicyRecognizer.onTap = () => _launch(privacyPolicyUrl);
+  }
+
+  @override
+  void dispose() {
+    _termsOfServiceRecognizer.dispose();
+    _privacyPolicyRecognizer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final baseStyle = Theme.of(context).textTheme.bodyMedium?.copyWith(
+      color: Theme.of(context).colorScheme.onSurface,
+    );
+    final linkStyle = baseStyle?.copyWith(
+      color: Theme.of(context).colorScheme.primary,
+      decoration: TextDecoration.underline,
+    );
+
+    return Text.rich(
+      TextSpan(
+        style: baseStyle,
+        children: [
+          const TextSpan(text: '「はじめる」をタップして利用を開始すると、\n'),
+          TextSpan(
+            text: '利用規約',
+            style: linkStyle,
+            recognizer: _termsOfServiceRecognizer,
+          ),
+          const TextSpan(text: 'と'),
+          TextSpan(
+            text: 'プライバシーポリシー',
+            style: linkStyle,
+            recognizer: _privacyPolicyRecognizer,
+          ),
+          const TextSpan(text: 'に同意したものとみなされます。'),
+        ],
+      ),
+      textAlign: TextAlign.center,
+    );
+  }
+
+  Future<void> _launch(String urlString) async {
+    final url = Uri.parse(urlString);
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url);
+    } else {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
+      }
+    }
   }
 }

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -164,14 +164,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         HapticFeedbackHelper.lightImpact();
         // 利用規約ページへのリンク
         final url = Uri.parse(termsOfServiceUrl);
-        if (await canLaunchUrl(url)) {
-          await launchUrl(url);
-        } else {
-          if (context.mounted) {
-            ScaffoldMessenger.of(
-              context,
-            ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
-          }
+        final launched = await launchUrl(url);
+
+        if (!launched && context.mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
         }
       },
     );
@@ -186,14 +184,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         HapticFeedbackHelper.lightImpact();
         // プライバシーポリシーページへのリンク
         final url = Uri.parse(privacyPolicyUrl);
-        if (await canLaunchUrl(url)) {
-          await launchUrl(url);
-        } else {
-          if (context.mounted) {
-            ScaffoldMessenger.of(
-              context,
-            ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
-          }
+        final launched = await launchUrl(url);
+
+        if (!launched && context.mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('URLを開けませんでした')));
         }
       },
     );

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -163,7 +163,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       onTap: () async {
         HapticFeedbackHelper.lightImpact();
         // 利用規約ページへのリンク
-        final url = Uri.parse('https://example.com/terms');
+        final url = Uri.parse(termsOfServiceUrl);
         if (await canLaunchUrl(url)) {
           await launchUrl(url);
         } else {
@@ -185,7 +185,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       onTap: () async {
         HapticFeedbackHelper.lightImpact();
         // プライバシーポリシーページへのリンク
-        final url = Uri.parse('https://example.com/privacy');
+        final url = Uri.parse(privacyPolicyUrl);
         if (await canLaunchUrl(url)) {
           await launchUrl(url);
         } else {

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -325,10 +325,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -897,10 +897,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      sha256: ce3f059ebd6dbfab7292bba0e893e354b46730636820d3c9ef69005ce2d55bce
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.4.0"
   mockito:
     dependency: transitive
     description:
@@ -953,10 +953,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1089,10 +1089,10 @@ packages:
     dependency: "direct main"
     description:
       name: purchases_flutter
-      sha256: "15c354a07aeabe1cda32fff84ce3e1d7e6645725cb7f9fca7c0738982d1b499d"
+      sha256: "2d02f74f88a890aca44962cac31c7f55fa6b28b18f6fa73c6da71b3cc878d969"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.1"
+    version: "10.4.3"
   record_use:
     dependency: transitive
     description:
@@ -1153,18 +1153,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.0"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## 概要

利用規約・プライバシーポリシーへの導線と同意フローを追加しました。あわせてログイン画面のレイアウトを画面サイズに対して堅牢にしています。

- 設定画面の「利用規約」「プライバシーポリシー」タイルのリンク先を、プレースホルダから実際の Notion ページの URL に差し替え（URL は `app_definition.dart` に集約）
- ログイン画面（最初の画面）に、「はじめる」をタップして利用を開始すると利用規約とプライバシーポリシーに同意したものとみなす旨の文言を追加。各文言はそれぞれのページへのタップ可能なリンク
- ログイン画面を横向きなどで縦幅が足りない場合でもオーバーフローせずスクロールできるように修正
- スクロール時にはコンテンツがセーフエリア外にも描画されるように調整（静止時のコンテンツ位置は SafeArea で確保）

## 追加・修正ファイル

- `client/lib/data/definition/app_definition.dart`: 利用規約・プライバシーポリシーの URL 定数を追加
- `client/lib/ui/feature/settings/settings_screen.dart`: 利用規約・プライバシーポリシーのリンク先を実際の URL に変更
- `client/lib/ui/feature/auth/login_screen.dart`: 同意文言（リンク付き）の追加、横向き時のスクロール対応、セーフエリア外描画の調整

## Related Issue

<!-- 作業指示者へ: 関連する Issue 番号を記載してください（例: close #123） -->

## Screenshots & Demo

<!-- 作業指示者へ: ログイン画面（縦向き・横向き）のスクリーンショットや動作デモを添付してください -->

## レビューで見て欲しいポイント

<!-- 作業指示者へ: 特にレビューしてほしい観点があれば記載してください -->
