### PR TITLE
feat: 結社マスターモードと雑談マスターモードの切り替え機能を追加

### DIFF
--- a/client/lib/data/model/chat_mode.dart
+++ b/client/lib/data/model/chat_mode.dart
@@ -1,0 +1,9 @@
+enum ChatMode {
+  /// Function Callingでプレクトラム結社の知識を参照して回答するモード。
+  ///
+  /// レスポンススキーマと同時には使用できないため、返信サジェストは付与されない。
+  plectrumSocietyMaster,
+
+  /// 返信サジェストを付与して雑談する回答をするモード。
+  chitChatMaster,
+}

--- a/client/lib/data/model/chat_mode_selection.dart
+++ b/client/lib/data/model/chat_mode_selection.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+
+part 'chat_mode_selection.freezed.dart';
+
+/// ユーザーが選択した回答モードの設定
+///
+/// [ChatModeSelectionAuto] の場合、会話の内容に応じてどちらの [ChatMode] を
+/// 使うかが自動的に決定される。
+@freezed
+sealed class ChatModeSelection with _$ChatModeSelection {
+  const factory ChatModeSelection.auto() = ChatModeSelectionAuto;
+  const factory ChatModeSelection.fixed(ChatMode mode) =
+      ChatModeSelectionFixed;
+}

--- a/client/lib/data/model/preference_key.dart
+++ b/client/lib/data/model/preference_key.dart
@@ -5,4 +5,5 @@ enum PreferenceKey {
   supportHistoryList,
   loginBonusGrantedDates,
   earnedBadgeList,
+  chatModeSelection,
 }

--- a/client/lib/data/repository/chat_mode_selection_repository.dart
+++ b/client/lib/data/repository/chat_mode_selection_repository.dart
@@ -1,0 +1,51 @@
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/data/model/chat_mode_selection.dart';
+import 'package:house_worker/data/model/preference_key.dart';
+import 'package:house_worker/data/service/preference_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'chat_mode_selection_repository.g.dart';
+
+@riverpod
+class ChatModeSelectionRepository extends _$ChatModeSelectionRepository {
+  @override
+  Future<ChatModeSelection> build() async {
+    final preferenceService = ref.read(preferenceServiceProvider);
+    final storedValue = await preferenceService.getString(
+      PreferenceKey.chatModeSelection,
+    );
+    return _decode(storedValue);
+  }
+
+  /// 回答モードの選択を保存する
+  Future<void> save(ChatModeSelection selection) async {
+    final preferenceService = ref.read(preferenceServiceProvider);
+    await preferenceService.setString(
+      PreferenceKey.chatModeSelection,
+      value: _encode(selection),
+    );
+
+    if (!ref.mounted) {
+      return;
+    }
+
+    state = AsyncValue.data(selection);
+  }
+
+  static ChatModeSelection _decode(String? storedValue) {
+    for (final mode in ChatMode.values) {
+      if (storedValue == mode.name) {
+        return ChatModeSelection.fixed(mode);
+      }
+    }
+
+    return const ChatModeSelection.auto();
+  }
+
+  static String _encode(ChatModeSelection selection) {
+    return switch (selection) {
+      ChatModeSelectionAuto() => 'auto',
+      ChatModeSelectionFixed(:final mode) => mode.name,
+    };
+  }
+}

--- a/client/lib/data/service/ai_chat_service.dart
+++ b/client/lib/data/service/ai_chat_service.dart
@@ -6,6 +6,7 @@ import 'package:firebase_ai/firebase_ai.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:house_worker/data/model/ai_response.dart';
 import 'package:house_worker/data/model/chat_message.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
 import 'package:house_worker/data/model/send_message_exception.dart';
 import 'package:house_worker/data/service/cavivara_knowledge_service.dart';
 import 'package:house_worker/data/service/error_report_service.dart';
@@ -32,10 +33,13 @@ class AiChatService {
   final CavivaraKnowledgeBase knowledgeBase;
   final Logger _logger = Logger('AiChatService');
 
-  /// チャットセッションのキャッシュ（systemPromptごとに保持）
+  /// チャットセッションのキャッシュ（systemPromptとChatModeの組み合わせごとに保持）
   final Map<String, ChatSession> _chatSessions = {};
 
   /// Response Schema定義（AIの返答形式を指定）
+  ///
+  /// FunctionCallingとレスポンススキーマの併用は不可なため、
+  /// [ChatMode.chitChatMaster] でのみ使用する。
   static final _aiResponseSchema = Schema.object(
     properties: {
       'content': Schema.string(
@@ -49,8 +53,11 @@ class AiChatService {
     optionalProperties: ['suggestedReplies'],
   );
 
-  /// Gemini 2.5 Flashモデルを取得（systemPromptを指定可能）
-  GenerativeModel _getModel(String systemPrompt) {
+  /// Gemini 2.5 Flashモデルを取得（systemPromptとChatModeを指定可能）
+  ///
+  /// FunctionCallingとレスポンススキーマは同時に指定できないため、
+  /// [mode] に応じてどちらか一方のみをモデルに設定する。
+  GenerativeModel _getModel(String systemPrompt, ChatMode mode) {
     return FirebaseAI.googleAI().generativeModel(
       model: 'gemini-2.5-flash',
       generationConfig: GenerationConfig(
@@ -62,13 +69,22 @@ class AiChatService {
         topK: 40,
         // 生成する最大トークン数
         maxOutputTokens: 2048,
-        // Response Schemaを使用して構造化レスポンスを取得
-        responseMimeType: 'application/json',
-        responseSchema: _aiResponseSchema,
+        // 雑談マスターモードのみ、Response Schemaを使用して構造化レスポンスを取得
+        responseMimeType: switch (mode) {
+          ChatMode.plectrumSocietyMaster => null,
+          ChatMode.chitChatMaster => 'application/json',
+        },
+        responseSchema: switch (mode) {
+          ChatMode.plectrumSocietyMaster => null,
+          ChatMode.chitChatMaster => _aiResponseSchema,
+        },
       ),
       systemInstruction: Content.system(systemPrompt),
-      // FunctionCallingとレスポンススキーマの併用は不可なので、一旦レスポンススキーマを優先
-      // tools: knowledgeBase.tools,
+      // プレクトラム結社マスターモードのみ、FunctionCallingを使用する
+      tools: switch (mode) {
+        ChatMode.plectrumSocietyMaster => knowledgeBase.tools,
+        ChatMode.chitChatMaster => null,
+      },
     );
   }
 
@@ -76,28 +92,34 @@ class AiChatService {
   ///
   /// [message] - 送信するメッセージ
   /// [systemPrompt] - 使用するシステムプロンプト（必須）
+  /// [mode] - 使用する回答モード（必須）
   /// [conversationHistory] - 会話履歴（指定された場合、新しいセッションを開始してhistoryを設定）
   ///
-  /// Response Schemaを使用して構造化されたAIレスポンスを返す
+  /// [ChatMode.chitChatMaster] の場合はResponse Schemaを使用して構造化された
+  /// AIレスポンスを返し、[ChatMode.plectrumSocietyMaster] の場合はFunction Calling
+  /// を使用してプレーンテキストのレスポンスを返す。
   Stream<AiResponse> sendMessageStream(
     String message, {
     required String systemPrompt,
+    required ChatMode mode,
     List<ChatMessage>? conversationHistory,
   }) {
     _logger.info(
       'Send message: $message with systemPrompt hash: '
-      '${systemPrompt.hashCode}',
+      '${systemPrompt.hashCode}, mode: $mode',
     );
 
     try {
       final chatSession = _createOrReuseChatSession(
         systemPrompt: systemPrompt,
+        mode: mode,
         conversationHistory: conversationHistory,
       );
 
       return _startMessageProcessing(
         chatSession: chatSession,
         message: message,
+        mode: mode,
       );
     } catch (e, stackTrace) {
       _logger.severe('ストリーミングチャットメッセージの送信に失敗: $e');
@@ -110,24 +132,33 @@ class AiChatService {
 
   ChatSession _createOrReuseChatSession({
     required String systemPrompt,
+    required ChatMode mode,
     List<ChatMessage>? conversationHistory,
   }) {
     if (conversationHistory != null) {
       // 会話履歴が指定された場合は新しいセッションを作成
-      final model = _getModel(systemPrompt);
+      final model = _getModel(systemPrompt, mode);
       final history = _convertChatHistoryToContent(conversationHistory);
       return model.startChat(history: history);
     }
 
     // 既存のセッションを取得または新規作成
-    final sessionKey = systemPrompt.hashCode.toString();
-    return _chatSessions[sessionKey] ??= _getModel(systemPrompt).startChat();
+    final sessionKey = _sessionKey(systemPrompt: systemPrompt, mode: mode);
+    return _chatSessions[sessionKey] ??= _getModel(
+      systemPrompt,
+      mode,
+    ).startChat();
+  }
+
+  String _sessionKey({required String systemPrompt, required ChatMode mode}) {
+    return '${systemPrompt.hashCode}_${mode.name}';
   }
 
   /// メッセージ処理を開始する
   Stream<AiResponse> _startMessageProcessing({
     required ChatSession chatSession,
     required String message,
+    required ChatMode mode,
   }) {
     final controller = StreamController<AiResponse>();
 
@@ -140,6 +171,7 @@ class AiChatService {
         chatSession: chatSession,
         responseStream: responseStream,
         controller: controller,
+        mode: mode,
       );
 
       await controller.close();
@@ -152,6 +184,7 @@ class AiChatService {
     required ChatSession chatSession,
     required Stream<GenerateContentResponse> responseStream,
     required StreamController<AiResponse> controller,
+    required ChatMode mode,
     int functionCallDepth = 0,
   }) async {
     // 関数呼び出しの最大深度を制限（無限再帰を防ぐ）
@@ -170,8 +203,8 @@ class AiChatService {
       return;
     }
     try {
-      // Response Schema使用時は、レスポンス全体がJSON形式で返される
-      // ストリーミング中のJSONテキストを蓄積
+      // Response Schema使用時（雑談マスターモード）は、レスポンス全体がJSON形式で
+      // 返されるため、ストリーミング中のJSONテキストを蓄積する
       final jsonBuffer = StringBuffer();
 
       await for (final chunk in responseStream) {
@@ -182,6 +215,7 @@ class AiChatService {
               chatSession: chatSession,
               functionCall: functionCall,
               controller: controller,
+              mode: mode,
               functionCallDepth: functionCallDepth,
             );
           }
@@ -199,7 +233,19 @@ class AiChatService {
         }
 
         _logger.info('応答チャンクを受信: $text');
-        jsonBuffer.write(text);
+
+        switch (mode) {
+          case ChatMode.plectrumSocietyMaster:
+            // Function Calling使用時はレスポンススキーマを使えないため、
+            // プレーンテキストのままチャンクごとに送出する
+            controller.add(AiResponse(content: text));
+          case ChatMode.chitChatMaster:
+            jsonBuffer.write(text);
+        }
+      }
+
+      if (mode == ChatMode.plectrumSocietyMaster) {
+        return;
       }
 
       // ストリーミング完了後、JSONをパースしてAiResponseを送信
@@ -252,6 +298,7 @@ class AiChatService {
     required ChatSession chatSession,
     required FunctionCall functionCall,
     required StreamController<AiResponse> controller,
+    required ChatMode mode,
     required int functionCallDepth,
   }) async {
     _logger.info(
@@ -275,6 +322,7 @@ class AiChatService {
         chatSession: chatSession,
         responseStream: chatSession.sendMessageStream(functionResponseContent),
         controller: controller,
+        mode: mode,
         functionCallDepth: functionCallDepth + 1,
       );
     } on Exception catch (e, stackTrace) {
@@ -338,10 +386,12 @@ class AiChatService {
         .toList();
   }
 
-  /// 特定のsystemPromptのチャットセッションをクリア
+  /// 特定のsystemPromptのチャットセッションをクリア（全ChatMode分）
   void clearChatSession(String systemPrompt) {
-    final sessionKey = systemPrompt.hashCode.toString();
-    _chatSessions.remove(sessionKey);
+    for (final mode in ChatMode.values) {
+      final sessionKey = _sessionKey(systemPrompt: systemPrompt, mode: mode);
+      _chatSessions.remove(sessionKey);
+    }
     _logger.info(
       'Chat session cleared for systemPrompt hash: '
       '${systemPrompt.hashCode}',

--- a/client/lib/data/service/ai_chat_service.dart
+++ b/client/lib/data/service/ai_chat_service.dart
@@ -80,7 +80,7 @@ class AiChatService {
         },
       ),
       systemInstruction: Content.system(systemPrompt),
-      // プレクトラム結社マスターモードのみ、FunctionCallingを使用する
+      // 結社マスターモードのみ、FunctionCallingを使用する
       tools: switch (mode) {
         ChatMode.plectrumSocietyMaster => knowledgeBase.tools,
         ChatMode.chitChatMaster => null,

--- a/client/lib/data/service/ai_chat_service.dart
+++ b/client/lib/data/service/ai_chat_service.dart
@@ -53,6 +53,19 @@ class AiChatService {
     optionalProperties: ['suggestedReplies'],
   );
 
+  /// 結社マスターモードで、モデルに Function Calling の利用を促すための追加指示。
+  ///
+  /// カヴィヴァラのプロンプトは自身を「百科事典級の知識を持つ専門家」と規定しており、
+  /// この指示がないとモデルは結社の公式情報も自前の知識で答えてしまい、
+  /// 提供済みの関数を呼び出さない（Function Calling が働かない）。
+  /// そのため、結社の公式情報・日時は必ず関数経由で取得するよう明示する。
+  static const String _plectrumSocietyToolInstruction = '''
+
+## 情報の取得ルール（厳守）
+- プレクトラム結社の公式情報（給与、定期演奏会、開催日時、会場、イベントなど）を尋ねられた場合は、必ず getPlectrumSocietyKnowledge 関数を呼び出して取得した内容のみを根拠に回答する。推測や記憶で答えてはならない。
+- 現在の日時や「今日」「今」など時点に依存する情報が必要な場合は、必ず getCurrentDateTime 関数を呼び出す。
+- 関数で該当情報が得られなかった場合は、分からない旨を正直に伝える。''';
+
   /// Gemini 2.5 Flashモデルを取得（systemPromptとChatModeを指定可能）
   ///
   /// FunctionCallingとレスポンススキーマは同時に指定できないため、
@@ -79,7 +92,12 @@ class AiChatService {
           ChatMode.chitChatMaster => _aiResponseSchema,
         },
       ),
-      systemInstruction: Content.system(systemPrompt),
+      // 結社マスターモードでは、Function Calling の利用を促す追加指示を付与する
+      systemInstruction: Content.system(switch (mode) {
+        ChatMode.plectrumSocietyMaster =>
+          '$systemPrompt$_plectrumSocietyToolInstruction',
+        ChatMode.chitChatMaster => systemPrompt,
+      }),
       // 結社マスターモードのみ、FunctionCallingを使用する
       tools: switch (mode) {
         ChatMode.plectrumSocietyMaster => knowledgeBase.tools,

--- a/client/lib/data/service/cavivara_knowledge_service.dart
+++ b/client/lib/data/service/cavivara_knowledge_service.dart
@@ -70,7 +70,7 @@ class CavivaraKnowledgeBase {
 
   /// 指定した文言が、結社の知識ベースに関連する内容かどうかを判定する。
   ///
-  /// 自動選択モードでの初回メッセージに対し、プレクトラム結社マスターモードと
+  /// 自動選択モードでの初回メッセージに対し、結社マスターモードと
   /// 雑談マスターモードのどちらを使うか判断する材料として利用する。
   bool hasRelevantKnowledge(String query) {
     final normalizedQuery = _normalizeQuery(query);

--- a/client/lib/data/service/cavivara_knowledge_service.dart
+++ b/client/lib/data/service/cavivara_knowledge_service.dart
@@ -68,6 +68,19 @@ class CavivaraKnowledgeBase {
 
   List<Tool> get tools => _knowledgeTools;
 
+  /// 指定した文言が、結社の知識ベースに関連する内容かどうかを判定する。
+  ///
+  /// 自動選択モードでの初回メッセージに対し、プレクトラム結社マスターモードと
+  /// 雑談マスターモードのどちらを使うか判断する材料として利用する。
+  bool hasRelevantKnowledge(String query) {
+    final normalizedQuery = _normalizeQuery(query);
+    if (normalizedQuery == null) {
+      return false;
+    }
+
+    return _entries.values.any((entry) => entry.matches(normalizedQuery));
+  }
+
   Future<Map<String, dynamic>> execute({
     required String functionName,
     Map<String, dynamic> arguments = const <String, dynamic>{},

--- a/client/lib/ui/component/chat_mode_extension.dart
+++ b/client/lib/ui/component/chat_mode_extension.dart
@@ -5,7 +5,7 @@ extension ChatModeExtension on ChatMode {
   String get displayName {
     switch (this) {
       case ChatMode.plectrumSocietyMaster:
-        return 'プレクトラム結社マスター';
+        return '結社マスター';
       case ChatMode.chitChatMaster:
         return '雑談マスター';
     }

--- a/client/lib/ui/component/chat_mode_extension.dart
+++ b/client/lib/ui/component/chat_mode_extension.dart
@@ -1,0 +1,31 @@
+import 'package:house_worker/data/model/chat_mode.dart';
+
+extension ChatModeExtension on ChatMode {
+  String get displayName {
+    switch (this) {
+      case ChatMode.plectrumSocietyMaster:
+        return 'プレクトラム結社マスターモード';
+      case ChatMode.chitChatMaster:
+        return '雑談マスターモード';
+    }
+  }
+
+  /// チャット画面のタイトル部分に表示する短いラベル
+  String get shortLabel {
+    switch (this) {
+      case ChatMode.plectrumSocietyMaster:
+        return '結社マスター';
+      case ChatMode.chitChatMaster:
+        return '雑談マスター';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case ChatMode.plectrumSocietyMaster:
+        return 'プレクトラム結社について、今来ている演奏会や過去の演奏会について知りたい場合に指定します。';
+      case ChatMode.chitChatMaster:
+        return '雑談をしたい場合に指定します。';
+    }
+  }
+}

--- a/client/lib/ui/component/chat_mode_extension.dart
+++ b/client/lib/ui/component/chat_mode_extension.dart
@@ -1,12 +1,13 @@
+import 'package:flutter/material.dart';
 import 'package:house_worker/data/model/chat_mode.dart';
 
 extension ChatModeExtension on ChatMode {
   String get displayName {
     switch (this) {
       case ChatMode.plectrumSocietyMaster:
-        return 'プレクトラム結社マスターモード';
+        return 'プレクトラム結社マスター';
       case ChatMode.chitChatMaster:
-        return '雑談マスターモード';
+        return '雑談マスター';
     }
   }
 
@@ -26,6 +27,18 @@ extension ChatModeExtension on ChatMode {
         return 'プレクトラム結社について、今来ている演奏会や過去の演奏会について知りたい場合に指定します。';
       case ChatMode.chitChatMaster:
         return '雑談をしたい場合に指定します。';
+    }
+  }
+
+  /// チャット画面のタイトル部分に表示する、モードを象徴するバッジの色。
+  ///
+  /// 結社マスターモードは赤、雑談マスターモードは青で表現する。
+  Color get badgeColor {
+    switch (this) {
+      case ChatMode.plectrumSocietyMaster:
+        return const Color(0xFFFF3B30);
+      case ChatMode.chitChatMaster:
+        return const Color(0xFF0A84FF);
     }
   }
 }

--- a/client/lib/ui/component/chat_mode_selection_dialog.dart
+++ b/client/lib/ui/component/chat_mode_selection_dialog.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/data/model/chat_mode_selection.dart';
+import 'package:house_worker/ui/component/chat_mode_extension.dart';
+import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
+
+class ChatModeSelectionDialog extends StatefulWidget {
+  const ChatModeSelectionDialog({required this.initialSelection, super.key});
+
+  final ChatModeSelection initialSelection;
+
+  @override
+  State<ChatModeSelectionDialog> createState() =>
+      _ChatModeSelectionDialogState();
+}
+
+class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
+  late ChatModeSelection _selection = widget.initialSelection;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('回答モードの選択'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildOption(
+              value: const ChatModeSelection.auto(),
+              title: '自動選択',
+              subtitle: '会話の内容にあわせて、最適なモードを自動的に選びます。',
+            ),
+            for (final mode in ChatMode.values)
+              _buildOption(
+                value: ChatModeSelection.fixed(mode),
+                title: mode.displayName,
+                subtitle: mode.description,
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            HapticFeedbackHelper.lightImpact();
+            Navigator.of(context).pop();
+          },
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed: () {
+            HapticFeedbackHelper.lightImpact();
+            Navigator.of(context).pop(_selection);
+          },
+          child: const Text('決定'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOption({
+    required ChatModeSelection value,
+    required String title,
+    required String subtitle,
+  }) {
+    return RadioListTile<ChatModeSelection>(
+      value: value,
+      groupValue: _selection,
+      contentPadding: EdgeInsets.zero,
+      title: Text(title),
+      subtitle: Text(subtitle),
+      onChanged: (selected) {
+        if (selected == null) {
+          return;
+        }
+        HapticFeedbackHelper.onToggle();
+        setState(() {
+          _selection = selected;
+        });
+      },
+    );
+  }
+}

--- a/client/lib/ui/component/chat_mode_selection_dialog.dart
+++ b/client/lib/ui/component/chat_mode_selection_dialog.dart
@@ -5,9 +5,18 @@ import 'package:house_worker/ui/component/chat_mode_extension.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
 
 class ChatModeSelectionDialog extends StatefulWidget {
-  const ChatModeSelectionDialog({required this.initialSelection, super.key});
+  const ChatModeSelectionDialog({
+    required this.initialSelection,
+    this.isLocked = false,
+    super.key,
+  });
 
   final ChatModeSelection initialSelection;
+
+  /// 会話が開始済みのため、モードを変更できないかどうか。
+  ///
+  /// `true` のときは選択肢を操作できず、現在のモードの確認のみ行える。
+  final bool isLocked;
 
   @override
   State<ChatModeSelectionDialog> createState() =>
@@ -20,16 +29,27 @@ class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('回答モードの選択'),
+      title: const Text('人格の選択'),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (widget.isLocked)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  '会話が始まると、人格は変更できません。'
+                  '記憶を消去すると、再び選べるようになります。',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
             _buildOption(
               value: const ChatModeSelection.auto(),
-              title: '自動選択',
-              subtitle: '会話の内容にあわせて、最適なモードを自動的に選びます。',
+              title: '人格の自動選択',
+              subtitle: '会話の内容にあわせて、最適な人格を自動的に選びます。',
             ),
             for (final mode in ChatMode.values)
               _buildOption(
@@ -46,15 +66,16 @@ class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
             HapticFeedbackHelper.lightImpact();
             Navigator.of(context).pop();
           },
-          child: const Text('キャンセル'),
+          child: Text(widget.isLocked ? '閉じる' : 'キャンセル'),
         ),
-        TextButton(
-          onPressed: () {
-            HapticFeedbackHelper.lightImpact();
-            Navigator.of(context).pop(_selection);
-          },
-          child: const Text('決定'),
-        ),
+        if (!widget.isLocked)
+          TextButton(
+            onPressed: () {
+              HapticFeedbackHelper.lightImpact();
+              Navigator.of(context).pop(_selection);
+            },
+            child: const Text('決定'),
+          ),
       ],
     );
   }
@@ -70,15 +91,18 @@ class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
       contentPadding: EdgeInsets.zero,
       title: Text(title),
       subtitle: Text(subtitle),
-      onChanged: (selected) {
-        if (selected == null) {
-          return;
-        }
-        HapticFeedbackHelper.onToggle();
-        setState(() {
-          _selection = selected;
-        });
-      },
+      // 会話が開始済みのときは選択を変更できないようにする。
+      onChanged: widget.isLocked
+          ? null
+          : (selected) {
+              if (selected == null) {
+                return;
+              }
+              HapticFeedbackHelper.onToggle();
+              setState(() {
+                _selection = selected;
+              });
+            },
     );
   }
 }

--- a/client/lib/ui/component/chat_mode_selection_dialog.dart
+++ b/client/lib/ui/component/chat_mode_selection_dialog.dart
@@ -31,33 +31,37 @@ class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
     return AlertDialog(
       title: const Text('人格の選択'),
       content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (widget.isLocked)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: Text(
-                  '会話が始まると、人格は変更できません。'
-                  '記憶を消去すると、再び選べるようになります。',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+        child: RadioGroup<ChatModeSelection>(
+          groupValue: _selection,
+          onChanged: _onOptionChanged,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (widget.isLocked)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    '会話が始まると、人格は変更できません。'
+                    '記憶を消去すると、再び選べるようになります。',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ),
-              ),
-            _buildOption(
-              value: const ChatModeSelection.auto(),
-              title: '人格の自動選択',
-              subtitle: '会話の内容にあわせて、最適な人格を自動的に選びます。',
-            ),
-            for (final mode in ChatMode.values)
               _buildOption(
-                value: ChatModeSelection.fixed(mode),
-                title: mode.displayName,
-                subtitle: mode.description,
+                value: const ChatModeSelection.auto(),
+                title: '人格の自動選択',
+                subtitle: '会話の内容にあわせて、最適な人格を自動的に選びます。',
               ),
-          ],
+              for (final mode in ChatMode.values)
+                _buildOption(
+                  value: ChatModeSelection.fixed(mode),
+                  title: mode.displayName,
+                  subtitle: mode.description,
+                ),
+            ],
+          ),
         ),
       ),
       actions: [
@@ -80,6 +84,16 @@ class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
     );
   }
 
+  void _onOptionChanged(ChatModeSelection? selected) {
+    if (selected == null) {
+      return;
+    }
+    HapticFeedbackHelper.onToggle();
+    setState(() {
+      _selection = selected;
+    });
+  }
+
   Widget _buildOption({
     required ChatModeSelection value,
     required String title,
@@ -87,22 +101,11 @@ class _ChatModeSelectionDialogState extends State<ChatModeSelectionDialog> {
   }) {
     return RadioListTile<ChatModeSelection>(
       value: value,
-      groupValue: _selection,
       contentPadding: EdgeInsets.zero,
       title: Text(title),
       subtitle: Text(subtitle),
       // 会話が開始済みのときは選択を変更できないようにする。
-      onChanged: widget.isLocked
-          ? null
-          : (selected) {
-              if (selected == null) {
-                return;
-              }
-              HapticFeedbackHelper.onToggle();
-              setState(() {
-                _selection = selected;
-              });
-            },
+      enabled: !widget.isLocked,
     );
   }
 }

--- a/client/lib/ui/feature/home/home_presenter.dart
+++ b/client/lib/ui/feature/home/home_presenter.dart
@@ -3,14 +3,18 @@ import 'dart:async';
 import 'package:house_worker/data/definition/app_feature.dart';
 import 'package:house_worker/data/model/app_badge.dart';
 import 'package:house_worker/data/model/chat_message.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/data/model/chat_mode_selection.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/data/model/send_message_exception.dart';
 import 'package:house_worker/data/model/supporter_title.dart';
+import 'package:house_worker/data/repository/chat_mode_selection_repository.dart';
 import 'package:house_worker/data/repository/earned_badges_repository.dart';
 import 'package:house_worker/data/repository/has_ever_sent_message_repository.dart';
 import 'package:house_worker/data/repository/login_bonus_granted_dates_repository.dart';
 import 'package:house_worker/data/repository/viva_point_repository.dart';
 import 'package:house_worker/data/service/ai_chat_service.dart';
+import 'package:house_worker/data/service/cavivara_knowledge_service.dart';
 import 'package:house_worker/data/service/cavivara_profile_service.dart';
 import 'package:house_worker/ui/component/heads_up_notification_presenter.dart';
 import 'package:house_worker/ui/component/supporter_title_extension.dart';
@@ -61,6 +65,8 @@ class ChatMessages extends _$ChatMessages {
     // 現在のチャット履歴を取得（AIサービスに会話履歴として渡すため）
     final conversationHistory = state.where((msg) => !msg.isStreaming).toList();
 
+    final chatMode = await _resolveChatMode(content);
+
     final aiMessageId = '${DateTime.now().millisecondsSinceEpoch}_ai';
     final thinkingMessage = ChatMessage(
       id: aiMessageId,
@@ -93,6 +99,7 @@ class ChatMessages extends _$ChatMessages {
       final responseStream = aiChatService.sendMessageStream(
         content,
         systemPrompt: systemPrompt,
+        mode: chatMode,
         conversationHistory: conversationHistory,
       );
 
@@ -173,9 +180,66 @@ class ChatMessages extends _$ChatMessages {
     // サジェストもクリア
     ref.read(suggestedRepliesProvider.notifier).clear();
 
+    // 自動選択モードで解決済みの回答モードもクリアし、次回会話の初回メッセージで
+    // 改めて判定できるようにする
+    ref.read(resolvedChatModeProvider.notifier).reset();
+
     // AIサービスのセッションキャッシュもクリア
     final cavivaraProfile = ref.read(cavivaraProfileProvider);
     ref.read(aiChatServiceProvider).clearChatSession(cavivaraProfile.aiPrompt);
+  }
+
+  /// 今回のメッセージ送信で使用する回答モードを解決する
+  ///
+  /// ユーザーが特定のモードを選択している場合はそれを使用し、自動選択モードの
+  /// 場合は会話中の最初のメッセージでのみ文言から判定し、以降はその判定結果を
+  /// 使い続ける（Gemini APIの都合上、Function Callingとレスポンススキーマは
+  /// 同一会話中で切り替えられないため）。
+  Future<ChatMode> _resolveChatMode(String content) async {
+    final selection = await ref.read(
+      chatModeSelectionRepositoryProvider.future,
+    );
+
+    return switch (selection) {
+      ChatModeSelectionFixed(:final mode) => mode,
+      ChatModeSelectionAuto() => _resolveAutoChatMode(content),
+    };
+  }
+
+  ChatMode _resolveAutoChatMode(String content) {
+    final alreadyResolvedMode = ref.read(resolvedChatModeProvider);
+    if (alreadyResolvedMode != null) {
+      return alreadyResolvedMode;
+    }
+
+    final knowledgeBase = ref.read(cavivaraKnowledgeBaseProvider);
+    final mode = knowledgeBase.hasRelevantKnowledge(content)
+        ? ChatMode.plectrumSocietyMaster
+        : ChatMode.chitChatMaster;
+
+    ref.read(resolvedChatModeProvider.notifier).resolve(mode);
+
+    return mode;
+  }
+}
+
+/// 自動選択モードにおいて、現在の会話で解決済みの回答モードを保持するプロバイダー
+///
+/// 会話をクリアするまでの間、自動選択の判定結果を保持し続けるために使用する
+@riverpod
+class ResolvedChatMode extends _$ResolvedChatMode {
+  @override
+  ChatMode? build() => null;
+
+  /// 自動選択の判定結果を保持する
+  // ignore: use_setters_to_change_properties
+  void resolve(ChatMode mode) {
+    state = mode;
+  }
+
+  /// 判定結果をクリアする
+  void reset() {
+    state = null;
   }
 }
 

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -231,6 +231,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                     selection: chatModeSelection,
                     resolvedMode: resolvedChatMode,
                   ),
+                  mode: _chatModeForBadge(
+                    selection: chatModeSelection,
+                    resolvedMode: resolvedChatMode,
+                  ),
                 ),
               ],
             ),
@@ -328,12 +332,29 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     return selection.whenOrNull(
           data: (value) => switch (value) {
             ChatModeSelectionFixed(:final mode) => mode.shortLabel,
-            ChatModeSelectionAuto() => resolvedMode != null
-                ? '自動選択（${resolvedMode.shortLabel}）'
-                : '自動選択',
+            ChatModeSelectionAuto() =>
+              resolvedMode != null
+                  ? '人格の自動選択（${resolvedMode.shortLabel}）'
+                  : '人格の自動選択',
           },
         ) ??
-        '自動選択';
+        '人格の自動選択';
+  }
+
+  /// バッジの色付けに使う、現在の回答モードを解決する。
+  ///
+  /// 自動選択でまだモードが確定していない場合は `null` を返し、
+  /// インジケーター側で中立色のバッジを表示する。
+  ChatMode? _chatModeForBadge({
+    required AsyncValue<ChatModeSelection> selection,
+    required ChatMode? resolvedMode,
+  }) {
+    return selection.whenOrNull(
+      data: (value) => switch (value) {
+        ChatModeSelectionFixed(:final mode) => mode,
+        ChatModeSelectionAuto() => resolvedMode,
+      },
+    );
   }
 
   Future<void> _showChatModeSelectionDialog() async {
@@ -347,10 +368,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       return;
     }
 
+    // 会話が始まっている（メッセージが存在する）間はモードを確定とし、変更できない。
+    // 記憶を消去してメッセージが空になると、再び選べるようになる。
+    final isLocked = ref.read(chatMessagesProvider).isNotEmpty;
+
     final result = await showDialog<ChatModeSelection>(
       context: context,
-      builder: (context) =>
-          ChatModeSelectionDialog(initialSelection: currentSelection),
+      builder: (context) => ChatModeSelectionDialog(
+        initialSelection: currentSelection,
+        isLocked: isLocked,
+      ),
     );
 
     if (result == null) {
@@ -508,9 +535,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
 /// チャット画面のタイトル下に、現在の回答モードをさりげなく表示するインジケーター
 class _ChatModeIndicator extends StatelessWidget {
-  const _ChatModeIndicator({required this.label});
+  const _ChatModeIndicator({required this.label, required this.mode});
 
   final String label;
+
+  /// 現在の回答モード。自動選択で未確定の場合は `null`。
+  final ChatMode? mode;
 
   @override
   Widget build(BuildContext context) {
@@ -519,8 +549,8 @@ class _ChatModeIndicator extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(Icons.tune, size: 12, color: mutedColor),
-        const SizedBox(width: 4),
+        _ChatModeGlowBadge(mode: mode),
+        const SizedBox(width: 6),
         Flexible(
           child: Text(
             label,
@@ -531,6 +561,109 @@ class _ChatModeIndicator extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// 回答モードを象徴する、定期的に発光する丸いバッジ。
+///
+/// 結社マスターモードは赤、雑談マスターモードは青で表示し、モードが未確定の
+/// 場合は中立色で発光を控えめにする。発光は明滅を繰り返すアニメーションで表現する。
+class _ChatModeGlowBadge extends StatefulWidget {
+  const _ChatModeGlowBadge({required this.mode});
+
+  final ChatMode? mode;
+
+  @override
+  State<_ChatModeGlowBadge> createState() => _ChatModeGlowBadgeState();
+}
+
+class _ChatModeGlowBadgeState extends State<_ChatModeGlowBadge>
+    with SingleTickerProviderStateMixin {
+  /// バッジ本体の直径。
+  static const _badgeSize = 10.0;
+
+  /// 明滅アニメーション1周期にかける時間。
+  static const _pulseDuration = Duration(milliseconds: 1600);
+
+  late final AnimationController _pulseController;
+  late final Animation<double> _pulse;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: _pulseDuration,
+    );
+    _pulse = CurvedAnimation(
+      parent: _pulseController,
+      curve: Curves.easeInOut,
+    );
+    _syncPulseWithMode();
+  }
+
+  @override
+  void didUpdateWidget(_ChatModeGlowBadge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.mode != widget.mode) {
+      _syncPulseWithMode();
+    }
+  }
+
+  /// モードの確定状況に応じて明滅アニメーションを開始・停止する。
+  ///
+  /// 自動選択でまだモードが確定していない（`mode` が `null`）場合は発光させず、
+  /// 静止したバッジのみを表示する。
+  void _syncPulseWithMode() {
+    if (widget.mode == null) {
+      // 発光を止め、最も弱い状態に戻す。
+      _pulseController
+        ..stop()
+        ..value = 0;
+      return;
+    }
+    // 発光が強まる→弱まるを永続的に繰り返す。
+    _pulseController.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // モード未確定時は中立色（控えめなグレー）で表示する。
+    final badgeColor =
+        widget.mode?.badgeColor ??
+        Theme.of(context).colorScheme.onSurfaceVariant;
+
+    return AnimatedBuilder(
+      animation: _pulse,
+      builder: (context, _) {
+        // 発光の強さを明滅させる。0.0〜1.0を行き来する値に応じて、
+        // 影のぼかし・広がり・不透明度を変化させる。
+        final t = _pulse.value;
+
+        return Container(
+          width: _badgeSize,
+          height: _badgeSize,
+          decoration: BoxDecoration(
+            color: badgeColor,
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: badgeColor.withValues(alpha: 0.3 + 0.5 * t),
+                blurRadius: 2 + 6 * t,
+                spreadRadius: 0.5 + 1.5 * t,
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -214,32 +214,35 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         ),
         const SizedBox(width: 12),
         Expanded(
-          child: InkWell(
-            onTap: _showChatModeSelectionDialog,
-            borderRadius: BorderRadius.circular(8),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  cavivaraProfile.displayName,
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 2,
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(left: 4),
-                  child: _ChatModeIndicator(
-                    label: _chatModeLabel(
-                      selection: chatModeSelection,
-                      resolvedMode: resolvedChatMode,
-                    ),
-                    mode: _chatModeForBadge(
-                      selection: chatModeSelection,
-                      resolvedMode: resolvedChatMode,
+          child: Tooltip(
+            message: '回答モードを選択する',
+            child: InkWell(
+              onTap: _showChatModeSelectionDialog,
+              borderRadius: BorderRadius.circular(8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    cavivaraProfile.displayName,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 2,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 4),
+                    child: _ChatModeIndicator(
+                      label: _chatModeLabel(
+                        selection: chatModeSelection,
+                        resolvedMode: resolvedChatMode,
+                      ),
+                      mode: _chatModeForBadge(
+                        selection: chatModeSelection,
+                        resolvedMode: resolvedChatMode,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -226,14 +226,17 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                   overflow: TextOverflow.ellipsis,
                   maxLines: 2,
                 ),
-                _ChatModeIndicator(
-                  label: _chatModeLabel(
-                    selection: chatModeSelection,
-                    resolvedMode: resolvedChatMode,
-                  ),
-                  mode: _chatModeForBadge(
-                    selection: chatModeSelection,
-                    resolvedMode: resolvedChatMode,
+                Padding(
+                  padding: const EdgeInsets.only(left: 4),
+                  child: _ChatModeIndicator(
+                    label: _chatModeLabel(
+                      selection: chatModeSelection,
+                      resolvedMode: resolvedChatMode,
+                    ),
+                    mode: _chatModeForBadge(
+                      selection: chatModeSelection,
+                      resolvedMode: resolvedChatMode,
+                    ),
                   ),
                 ),
               ],
@@ -333,9 +336,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           data: (value) => switch (value) {
             ChatModeSelectionFixed(:final mode) => mode.shortLabel,
             ChatModeSelectionAuto() =>
-              resolvedMode != null
-                  ? '人格の自動選択（${resolvedMode.shortLabel}）'
-                  : '人格の自動選択',
+              resolvedMode != null ? resolvedMode.shortLabel : '人格の自動選択',
           },
         ) ??
         '人格の自動選択';

--- a/client/lib/ui/feature/home/home_screen.dart
+++ b/client/lib/ui/feature/home/home_screen.dart
@@ -5,12 +5,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:house_worker/data/model/chat_bubble_design.dart';
 import 'package:house_worker/data/model/chat_message.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/data/model/chat_mode_selection.dart';
+import 'package:house_worker/data/repository/chat_mode_selection_repository.dart';
 import 'package:house_worker/data/repository/skip_clear_chat_confirmation_repository.dart';
 import 'package:house_worker/data/service/cavivara_profile_service.dart';
 import 'package:house_worker/ui/component/animated_cavivara.dart';
 import 'package:house_worker/ui/component/app_drawer.dart';
 import 'package:house_worker/ui/component/cat_fur_bubble_painter.dart';
 import 'package:house_worker/ui/component/chat_bubble_design_extension.dart';
+import 'package:house_worker/ui/component/chat_mode_extension.dart';
+import 'package:house_worker/ui/component/chat_mode_selection_dialog.dart';
 import 'package:house_worker/ui/component/clear_chat_confirmation_dialog.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
 import 'package:house_worker/ui/component/suggested_reply_list.dart';
@@ -181,6 +186,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   @override
   Widget build(BuildContext context) {
     final cavivaraProfile = ref.watch(cavivaraProfileProvider);
+    final chatModeSelection = ref.watch(chatModeSelectionRepositoryProvider);
+    final resolvedChatMode = ref.watch(resolvedChatModeProvider);
 
     final title = Row(
       children: [
@@ -207,10 +214,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         ),
         const SizedBox(width: 12),
         Expanded(
-          child: Text(
-            cavivaraProfile.displayName,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2,
+          child: InkWell(
+            onTap: _showChatModeSelectionDialog,
+            borderRadius: BorderRadius.circular(8),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  cavivaraProfile.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 2,
+                ),
+                _ChatModeIndicator(
+                  label: _chatModeLabel(
+                    selection: chatModeSelection,
+                    resolvedMode: resolvedChatMode,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ],
@@ -296,6 +319,49 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         child: scaffold,
       ),
     );
+  }
+
+  String _chatModeLabel({
+    required AsyncValue<ChatModeSelection> selection,
+    required ChatMode? resolvedMode,
+  }) {
+    return selection.whenOrNull(
+          data: (value) => switch (value) {
+            ChatModeSelectionFixed(:final mode) => mode.shortLabel,
+            ChatModeSelectionAuto() => resolvedMode != null
+                ? '自動選択（${resolvedMode.shortLabel}）'
+                : '自動選択',
+          },
+        ) ??
+        '自動選択';
+  }
+
+  Future<void> _showChatModeSelectionDialog() async {
+    HapticFeedbackHelper.onDialogShow();
+
+    final currentSelection = await ref.read(
+      chatModeSelectionRepositoryProvider.future,
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    final result = await showDialog<ChatModeSelection>(
+      context: context,
+      builder: (context) =>
+          ChatModeSelectionDialog(initialSelection: currentSelection),
+    );
+
+    if (result == null) {
+      return;
+    }
+
+    await ref.read(chatModeSelectionRepositoryProvider.notifier).save(result);
+
+    // 選択が変わった場合に備え、自動選択の判定結果をリセットし、次のメッセージで
+    // 改めて判定できるようにする
+    ref.read(resolvedChatModeProvider.notifier).reset();
   }
 
   Future<void> _clearChat() async {
@@ -436,6 +502,35 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           ),
         ],
       ),
+    );
+  }
+}
+
+/// チャット画面のタイトル下に、現在の回答モードをさりげなく表示するインジケーター
+class _ChatModeIndicator extends StatelessWidget {
+  const _ChatModeIndicator({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final mutedColor = Theme.of(context).colorScheme.onSurfaceVariant;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.tune, size: 12, color: mutedColor),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            label,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(
+              context,
+            ).textTheme.labelSmall?.copyWith(color: mutedColor),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/client/test/data/repository/chat_mode_selection_repository_test.dart
+++ b/client/test/data/repository/chat_mode_selection_repository_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/data/model/chat_mode_selection.dart';
+import 'package:house_worker/data/model/preference_key.dart';
+import 'package:house_worker/data/repository/chat_mode_selection_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+void main() {
+  group('ChatModeSelectionRepository', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    group('初期状態', () {
+      test('永続化データがない場合は自動選択が返されること', () async {
+        final selection = await container.read(
+          chatModeSelectionRepositoryProvider.future,
+        );
+
+        expect(selection, equals(const ChatModeSelection.auto()));
+      });
+
+      test('永続化データが存在する場合は永続化された値で初期化されること', () async {
+        container.dispose();
+        SharedPreferences.setMockInitialValues({
+          PreferenceKey.chatModeSelection.name:
+              ChatMode.plectrumSocietyMaster.name,
+        });
+        SharedPreferencesAsyncPlatform.instance =
+            InMemorySharedPreferencesAsync.withData({
+              PreferenceKey.chatModeSelection.name:
+                  ChatMode.plectrumSocietyMaster.name,
+            });
+        container = ProviderContainer();
+
+        final selection = await container.read(
+          chatModeSelectionRepositoryProvider.future,
+        );
+
+        expect(
+          selection,
+          equals(
+            const ChatModeSelection.fixed(ChatMode.plectrumSocietyMaster),
+          ),
+        );
+      });
+    });
+
+    group('保存', () {
+      test('自動選択を保存できること', () async {
+        await container
+            .read(chatModeSelectionRepositoryProvider.notifier)
+            .save(const ChatModeSelection.fixed(ChatMode.chitChatMaster));
+
+        await container
+            .read(chatModeSelectionRepositoryProvider.notifier)
+            .save(const ChatModeSelection.auto());
+
+        final selection = await container.read(
+          chatModeSelectionRepositoryProvider.future,
+        );
+        expect(selection, equals(const ChatModeSelection.auto()));
+      });
+
+      test('固定モードを保存できること', () async {
+        await container
+            .read(chatModeSelectionRepositoryProvider.notifier)
+            .save(const ChatModeSelection.fixed(ChatMode.chitChatMaster));
+
+        final selection = await container.read(
+          chatModeSelectionRepositoryProvider.future,
+        );
+        expect(
+          selection,
+          equals(const ChatModeSelection.fixed(ChatMode.chitChatMaster)),
+        );
+      });
+
+      test('保存した内容が永続化されること', () async {
+        await container
+            .read(chatModeSelectionRepositoryProvider.notifier)
+            .save(
+              const ChatModeSelection.fixed(ChatMode.plectrumSocietyMaster),
+            );
+
+        final newContainer = ProviderContainer();
+        addTearDown(newContainer.dispose);
+        final selection = await newContainer.read(
+          chatModeSelectionRepositoryProvider.future,
+        );
+
+        expect(
+          selection,
+          equals(
+            const ChatModeSelection.fixed(ChatMode.plectrumSocietyMaster),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/client/test/data/service/cavivara_knowledge_service_test.dart
+++ b/client/test/data/service/cavivara_knowledge_service_test.dart
@@ -81,6 +81,26 @@ void main() {
       },
     );
 
+    test(
+      'returns true from hasRelevantKnowledge when query matches a keyword',
+      () {
+        expect(
+          knowledgeBase.hasRelevantKnowledge('定期演奏会はいつ開催されるの？'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns false from hasRelevantKnowledge when query matches nothing',
+      () {
+        expect(
+          knowledgeBase.hasRelevantKnowledge('今日の天気は？'),
+          isFalse,
+        );
+      },
+    );
+
     test('returns current date time information', () async {
       final start = DateTime.now().toUtc();
 

--- a/client/test/ui/component/chat_mode_extension_test.dart
+++ b/client/test/ui/component/chat_mode_extension_test.dart
@@ -7,11 +7,11 @@ void main() {
     test('displayName はモードごとに一意な表示名を返すこと', () {
       expect(
         ChatMode.plectrumSocietyMaster.displayName,
-        equals('結社マスターモード'),
+        equals('結社マスター'),
       );
       expect(
         ChatMode.chitChatMaster.displayName,
-        equals('雑談マスターモード'),
+        equals('雑談マスター'),
       );
     });
 

--- a/client/test/ui/component/chat_mode_extension_test.dart
+++ b/client/test/ui/component/chat_mode_extension_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/ui/component/chat_mode_extension.dart';
+
+void main() {
+  group('ChatModeExtension', () {
+    test('displayName はモードごとに一意な表示名を返すこと', () {
+      expect(
+        ChatMode.plectrumSocietyMaster.displayName,
+        equals('プレクトラム結社マスターモード'),
+      );
+      expect(
+        ChatMode.chitChatMaster.displayName,
+        equals('雑談マスターモード'),
+      );
+    });
+
+    test('shortLabel はモードごとに一意な短いラベルを返すこと', () {
+      expect(
+        ChatMode.plectrumSocietyMaster.shortLabel,
+        isNotEmpty,
+      );
+      expect(
+        ChatMode.chitChatMaster.shortLabel,
+        isNotEmpty,
+      );
+      expect(
+        ChatMode.plectrumSocietyMaster.shortLabel,
+        isNot(equals(ChatMode.chitChatMaster.shortLabel)),
+      );
+    });
+
+    test('description はモードごとに空でない説明を返すこと', () {
+      for (final mode in ChatMode.values) {
+        expect(mode.description, isNotEmpty);
+      }
+    });
+  });
+}

--- a/client/test/ui/component/chat_mode_extension_test.dart
+++ b/client/test/ui/component/chat_mode_extension_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('displayName はモードごとに一意な表示名を返すこと', () {
       expect(
         ChatMode.plectrumSocietyMaster.displayName,
-        equals('プレクトラム結社マスターモード'),
+        equals('結社マスターモード'),
       );
       expect(
         ChatMode.chitChatMaster.displayName,

--- a/client/test/ui/component/chat_mode_selection_dialog_test.dart
+++ b/client/test/ui/component/chat_mode_selection_dialog_test.dart
@@ -50,13 +50,15 @@ void main() {
         onResult: (_) {},
       );
 
-      final radio = tester.widget<RadioListTile<ChatModeSelection>>(
-        find.widgetWithText(
-          RadioListTile<ChatModeSelection>,
-          ChatMode.plectrumSocietyMaster.displayName,
+      final group = tester.widget<RadioGroup<ChatModeSelection>>(
+        find.byType(RadioGroup<ChatModeSelection>),
+      );
+      expect(
+        group.groupValue,
+        equals(
+          const ChatModeSelection.fixed(ChatMode.plectrumSocietyMaster),
         ),
       );
-      expect(radio.groupValue, equals(radio.value));
     });
 
     testWidgets('モードを選択して決定すると、選択結果が返されること', (tester) async {
@@ -110,14 +112,14 @@ void main() {
         isLocked: true,
       );
 
-      // 選択肢は無効化されており、onChanged が設定されていないこと。
+      // 選択肢は無効化されており、操作できないこと。
       final radio = tester.widget<RadioListTile<ChatModeSelection>>(
         find.widgetWithText(
           RadioListTile<ChatModeSelection>,
           ChatMode.chitChatMaster.displayName,
         ),
       );
-      expect(radio.onChanged, isNull);
+      expect(radio.enabled, isFalse);
 
       // 決定ボタンは表示されず、閉じるボタンのみが表示されること。
       expect(find.text('決定'), findsNothing);

--- a/client/test/ui/component/chat_mode_selection_dialog_test.dart
+++ b/client/test/ui/component/chat_mode_selection_dialog_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
+import 'package:house_worker/data/model/chat_mode_selection.dart';
+import 'package:house_worker/ui/component/chat_mode_extension.dart';
+import 'package:house_worker/ui/component/chat_mode_selection_dialog.dart';
+
+void main() {
+  Future<void> pumpAndOpenDialog(
+    WidgetTester tester, {
+    required ChatModeSelection initialSelection,
+    required ValueChanged<ChatModeSelection?> onResult,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  final result = await showDialog<ChatModeSelection>(
+                    context: context,
+                    builder: (context) => ChatModeSelectionDialog(
+                      initialSelection: initialSelection,
+                    ),
+                  );
+                  onResult(result);
+                },
+                child: const Text('open'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('ChatModeSelectionDialog', () {
+    testWidgets('初期選択が反映されていること', (tester) async {
+      await pumpAndOpenDialog(
+        tester,
+        initialSelection: const ChatModeSelection.fixed(
+          ChatMode.plectrumSocietyMaster,
+        ),
+        onResult: (_) {},
+      );
+
+      final radio = tester.widget<RadioListTile<ChatModeSelection>>(
+        find.widgetWithText(
+          RadioListTile<ChatModeSelection>,
+          ChatMode.plectrumSocietyMaster.displayName,
+        ),
+      );
+      expect(radio.groupValue, equals(radio.value));
+    });
+
+    testWidgets('モードを選択して決定すると、選択結果が返されること', (tester) async {
+      ChatModeSelection? result;
+
+      await pumpAndOpenDialog(
+        tester,
+        initialSelection: const ChatModeSelection.auto(),
+        onResult: (value) => result = value,
+      );
+
+      await tester.tap(find.text(ChatMode.chitChatMaster.displayName));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('決定'));
+      await tester.pumpAndSettle();
+
+      expect(
+        result,
+        equals(const ChatModeSelection.fixed(ChatMode.chitChatMaster)),
+      );
+    });
+
+    testWidgets('キャンセルするとnullが返されること', (tester) async {
+      var onResultCalled = false;
+      ChatModeSelection? result;
+
+      await pumpAndOpenDialog(
+        tester,
+        initialSelection: const ChatModeSelection.auto(),
+        onResult: (value) {
+          onResultCalled = true;
+          result = value;
+        },
+      );
+
+      await tester.tap(find.text('キャンセル'));
+      await tester.pumpAndSettle();
+
+      expect(onResultCalled, isTrue);
+      expect(result, isNull);
+    });
+  });
+}

--- a/client/test/ui/component/chat_mode_selection_dialog_test.dart
+++ b/client/test/ui/component/chat_mode_selection_dialog_test.dart
@@ -10,6 +10,7 @@ void main() {
     WidgetTester tester, {
     required ChatModeSelection initialSelection,
     required ValueChanged<ChatModeSelection?> onResult,
+    bool isLocked = false,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -22,6 +23,7 @@ void main() {
                     context: context,
                     builder: (context) => ChatModeSelectionDialog(
                       initialSelection: initialSelection,
+                      isLocked: isLocked,
                     ),
                   );
                   onResult(result);
@@ -92,6 +94,51 @@ void main() {
       );
 
       await tester.tap(find.text('キャンセル'));
+      await tester.pumpAndSettle();
+
+      expect(onResultCalled, isTrue);
+      expect(result, isNull);
+    });
+
+    testWidgets('ロック中は選択肢を操作できず、決定ボタンが表示されないこと', (tester) async {
+      await pumpAndOpenDialog(
+        tester,
+        initialSelection: const ChatModeSelection.fixed(
+          ChatMode.plectrumSocietyMaster,
+        ),
+        onResult: (_) {},
+        isLocked: true,
+      );
+
+      // 選択肢は無効化されており、onChanged が設定されていないこと。
+      final radio = tester.widget<RadioListTile<ChatModeSelection>>(
+        find.widgetWithText(
+          RadioListTile<ChatModeSelection>,
+          ChatMode.chitChatMaster.displayName,
+        ),
+      );
+      expect(radio.onChanged, isNull);
+
+      // 決定ボタンは表示されず、閉じるボタンのみが表示されること。
+      expect(find.text('決定'), findsNothing);
+      expect(find.text('閉じる'), findsOneWidget);
+    });
+
+    testWidgets('ロック中に閉じるとnullが返されること', (tester) async {
+      var onResultCalled = false;
+      ChatModeSelection? result;
+
+      await pumpAndOpenDialog(
+        tester,
+        initialSelection: const ChatModeSelection.auto(),
+        onResult: (value) {
+          onResultCalled = true;
+          result = value;
+        },
+        isLocked: true,
+      );
+
+      await tester.tap(find.text('閉じる'));
       await tester.pumpAndSettle();
 
       expect(onResultCalled, isTrue);

--- a/client/test/ui/feature/home/home_presenter_test.dart
+++ b/client/test/ui/feature/home/home_presenter_test.dart
@@ -4,6 +4,7 @@ import 'package:house_worker/data/model/ai_response.dart';
 import 'package:house_worker/data/model/app_badge.dart';
 import 'package:house_worker/data/model/cavivara_profile.dart';
 import 'package:house_worker/data/model/chat_message.dart';
+import 'package:house_worker/data/model/chat_mode.dart';
 import 'package:house_worker/data/model/earned_badge.dart';
 import 'package:house_worker/data/model/preference_key.dart';
 import 'package:house_worker/data/model/send_message_exception.dart';
@@ -25,6 +26,7 @@ void main() {
   setUpAll(() {
     // Register fallback values for mocktail matchers
     registerFallbackValue(PreferenceKey.skipClearChatConfirmation);
+    registerFallbackValue(ChatMode.chitChatMaster);
   });
 
   group('Home Presenter - Chat Messages', () {
@@ -54,6 +56,11 @@ void main() {
           value: any(named: 'value'),
         ),
       ).thenAnswer((_) async {});
+
+      // ChatModeSelectionRepository用のモック（未設定時は自動選択扱い）
+      when(
+        () => mockPreferenceService.getString(any()),
+      ).thenAnswer((_) async => null);
 
       // テスト用のカヴィヴァラプロフィールを作成
       const testCavivaraProfile = CavivaraProfile(
@@ -99,6 +106,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             messageText,
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -133,6 +141,7 @@ void main() {
             () => mockAiChatService.sendMessageStream(
               messageText,
               systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: any(named: 'mode'),
               conversationHistory: any<List<ChatMessage>?>(
                 named: 'conversationHistory',
               ),
@@ -151,6 +160,119 @@ void main() {
             () => mockAiChatService.sendMessageStream(
               messageText,
               systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: any(named: 'mode'),
+              conversationHistory: any<List<ChatMessage>?>(
+                named: 'conversationHistory',
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        '雑談を示唆する文言の場合、雑談マスターモードで呼び出されること',
+        () async {
+          const messageText = '今日はいい天気だね';
+
+          when(
+            () => mockAiChatService.sendMessageStream(
+              messageText,
+              systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: any(named: 'mode'),
+              conversationHistory: any<List<ChatMessage>?>(
+                named: 'conversationHistory',
+              ),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(
+              const AiResponse(content: 'AIからの返信'),
+            ),
+          );
+
+          final notifier = container.read(chatMessagesProvider.notifier);
+          await notifier.sendMessage(messageText);
+
+          verify(
+            () => mockAiChatService.sendMessageStream(
+              messageText,
+              systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: ChatMode.chitChatMaster,
+              conversationHistory: any<List<ChatMessage>?>(
+                named: 'conversationHistory',
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        '結社の知識に関連する文言の場合、結社マスターモードで呼び出されること',
+        () async {
+          const messageText = '次の定期演奏会はいつ開催されますか？';
+
+          when(
+            () => mockAiChatService.sendMessageStream(
+              messageText,
+              systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: any(named: 'mode'),
+              conversationHistory: any<List<ChatMessage>?>(
+                named: 'conversationHistory',
+              ),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(
+              const AiResponse(content: 'AIからの返信'),
+            ),
+          );
+
+          final notifier = container.read(chatMessagesProvider.notifier);
+          await notifier.sendMessage(messageText);
+
+          verify(
+            () => mockAiChatService.sendMessageStream(
+              messageText,
+              systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: ChatMode.plectrumSocietyMaster,
+              conversationHistory: any<List<ChatMessage>?>(
+                named: 'conversationHistory',
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        '自動選択モードでは、会話中の2通目以降は初回の判定結果が使われ続けること',
+        () async {
+          const firstMessage = '次の定期演奏会はいつ開催されますか？';
+          const secondMessage = '今日はいい天気だね';
+
+          when(
+            () => mockAiChatService.sendMessageStream(
+              any<String>(),
+              systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: any(named: 'mode'),
+              conversationHistory: any<List<ChatMessage>?>(
+                named: 'conversationHistory',
+              ),
+            ),
+          ).thenAnswer(
+            (_) => Stream.value(
+              const AiResponse(content: 'AIからの返信'),
+            ),
+          );
+
+          final notifier = container.read(chatMessagesProvider.notifier);
+          await notifier.sendMessage(firstMessage);
+          await notifier.sendMessage(secondMessage);
+
+          // 2通目は雑談を示唆する文言だが、初回に判定した結社マスターモードが
+          // 維持されること
+          verify(
+            () => mockAiChatService.sendMessageStream(
+              secondMessage,
+              systemPrompt: any<String>(named: 'systemPrompt'),
+              mode: ChatMode.plectrumSocietyMaster,
               conversationHistory: any<List<ChatMessage>?>(
                 named: 'conversationHistory',
               ),
@@ -166,6 +288,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             messageText,
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -199,6 +322,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             messageText,
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -230,6 +354,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             any<String>(),
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -350,6 +475,9 @@ void main() {
             value: any(named: 'value'),
           ),
         ).thenAnswer((_) async {});
+        when(
+          () => mockPreferenceService.getString(any()),
+        ).thenAnswer((_) async => null);
 
         container = ProviderContainer(
           overrides: [
@@ -392,6 +520,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             any<String>(),
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -420,6 +549,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             messageText,
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -450,6 +580,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             messageText,
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),
@@ -477,6 +608,7 @@ void main() {
           () => mockAiChatService.sendMessageStream(
             messageText,
             systemPrompt: any<String>(named: 'systemPrompt'),
+            mode: any(named: 'mode'),
             conversationHistory: any<List<ChatMessage>?>(
               named: 'conversationHistory',
             ),

--- a/doc/design/chat-mode-selection.md
+++ b/doc/design/chat-mode-selection.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-カヴィヴァラの回答モードを「プレクトラム結社マスターモード（Function Calling を利用し、結社の演奏会情報などを回答する）」と「雑談マスターモード（返信サジェストを付与して雑談する）」から選択できる機能の技術的な設計概要を示す。
+カヴィヴァラの回答モードを「結社マスターモード（Function Calling を利用し、結社の演奏会情報などを回答する）」と「雑談マスターモード（返信サジェストを付与して雑談する）」から選択できる機能の技術的な設計概要を示す。
 
 Gemini API は Function Calling とレスポンススキーマ（構造化出力）を同一リクエストで併用できないため、これら 2 つの回答方式は排他的に切り替える必要がある。
 
@@ -13,21 +13,17 @@ Gemini API は Function Calling とレスポンススキーマ（構造化出力
 本機能は以下の層で実装する：
 
 1. **UI Layer** - ユーザーインターフェース
-
    - チャット画面タイトル下のモードインジケーター（HomeScreen 内）
    - モード選択ダイアログ（ChatModeSelectionDialog）
 
 2. **Presenter Layer** - 状態管理・判定ロジック
-
    - `ChatMessages`（送信時のモード解決）
    - `ResolvedChatMode`（自動選択モードでの会話中の判定結果保持）
 
 3. **Repository Layer** - データ永続化
-
    - `ChatModeSelectionRepository`
 
 4. **Service Layer** - Gemini API 呼び出し
-
    - `AiChatService`（モードに応じたモデル設定の切り替え）
    - `CavivaraKnowledgeBase`（自動選択判定のための知識ベース参照）
 
@@ -105,7 +101,7 @@ Gemini API 側の制約上、同一会話中でレスポンススキーマと Fu
 **内容**:
 
 - チャット画面タイトル（カヴィヴァラの表示名）の下に、現在の回答モードを示す小さなラベルを表示
-- ラベルをタップすると `ChatModeSelectionDialog` を表示し、「自動選択」「プレクトラム結社マスターモード」「雑談マスターモード」を `RadioListTile` で選択できる
+- ラベルをタップすると `ChatModeSelectionDialog` を表示し、「自動選択」「結社マスターモード」「雑談マスターモード」を `RadioListTile` で選択できる
 - 選択を保存すると、自動選択の判定結果（`ResolvedChatMode`）をリセットし、次のメッセージから改めて判定できるようにする
 
 ## データフロー

--- a/doc/design/chat-mode-selection.md
+++ b/doc/design/chat-mode-selection.md
@@ -1,0 +1,130 @@
+# 回答モード切り替え機能（結社マスターモード／雑談マスターモード）概要設計書
+
+## 目的
+
+カヴィヴァラの回答モードを「プレクトラム結社マスターモード（Function Calling を利用し、結社の演奏会情報などを回答する）」と「雑談マスターモード（返信サジェストを付与して雑談する）」から選択できる機能の技術的な設計概要を示す。
+
+Gemini API は Function Calling とレスポンススキーマ（構造化出力）を同一リクエストで併用できないため、これら 2 つの回答方式は排他的に切り替える必要がある。
+
+## アーキテクチャ
+
+### レイヤー構成
+
+本機能は以下の層で実装する：
+
+1. **UI Layer** - ユーザーインターフェース
+
+   - チャット画面タイトル下のモードインジケーター（HomeScreen 内）
+   - モード選択ダイアログ（ChatModeSelectionDialog）
+
+2. **Presenter Layer** - 状態管理・判定ロジック
+
+   - `ChatMessages`（送信時のモード解決）
+   - `ResolvedChatMode`（自動選択モードでの会話中の判定結果保持）
+
+3. **Repository Layer** - データ永続化
+
+   - `ChatModeSelectionRepository`
+
+4. **Service Layer** - Gemini API 呼び出し
+
+   - `AiChatService`（モードに応じたモデル設定の切り替え）
+   - `CavivaraKnowledgeBase`（自動選択判定のための知識ベース参照）
+
+5. **Data Layer** - ストレージ
+   - SharedPreferences
+
+## 主要コンポーネント
+
+### 1. ChatMode（ドメインモデル）
+
+**配置**: `client/lib/data/model/chat_mode.dart`
+
+**役割**: 実際にAIへの問い合わせで使用する回答モードを表す enum
+
+**内容**:
+
+- `plectrumSocietyMaster`: Function Calling でプレクトラム結社の知識を参照して回答するモード
+- `chitChatMaster`: 返信サジェストを付与して雑談する回答をするモード
+
+### 2. ChatModeSelection（ドメインモデル）
+
+**配置**: `client/lib/data/model/chat_mode_selection.dart`
+
+**役割**: ユーザーが選択した「モードの決め方」を表す sealed freezed クラス
+
+**内容**:
+
+- `ChatModeSelection.auto()`: 会話内容に応じて自動的に `ChatMode` を判定する
+- `ChatModeSelection.fixed(ChatMode mode)`: 常に指定した `ChatMode` を使用する
+
+### 3. ChatModeExtension（UI 拡張）
+
+**配置**: `client/lib/ui/component/chat_mode_extension.dart`
+
+**役割**: `ChatMode` に表示名・短いラベル・説明文などの UI 関連プロパティを付与する
+
+### 4. ChatModeSelectionRepository（永続化）
+
+**配置**: `client/lib/data/repository/chat_mode_selection_repository.dart`
+
+**役割**: モード選択設定の読み込みと保存
+
+- `build()`: SharedPreferences から設定を読み込み、未設定の場合は自動選択をデフォルトとする
+- `save(selection)`: 選択された `ChatModeSelection` を SharedPreferences に保存（`auto` または `ChatMode.name`）
+
+### 5. ResolvedChatMode（会話中の判定結果保持）
+
+**配置**: `client/lib/ui/feature/home/home_presenter.dart`
+
+**役割**: 自動選択モードにおいて、会話中の最初のメッセージで判定した `ChatMode` を、チャットをクリアするまで保持する
+
+Gemini API 側の制約上、同一会話中でレスポンススキーマと Function Calling を切り替えることはできないため、自動選択モードであっても会話単位でモードを固定する必要がある。
+
+### 6. CavivaraKnowledgeBase.hasRelevantKnowledge（自動選択の判定材料）
+
+**配置**: `client/lib/data/service/cavivara_knowledge_service.dart`
+
+**役割**: 入力文言が結社の知識ベースのキーワードに合致するかどうかを判定する。既存の Function Calling 用知識エントリ（`_entries`）のキーワード一致ロジックを再利用し、自動選択モードでの初回メッセージの判定に使用する。
+
+### 7. AiChatService のモード対応
+
+**配置**: `client/lib/data/service/ai_chat_service.dart`
+
+**変更内容**:
+
+- `sendMessageStream` / `_getModel` / `_createOrReuseChatSession` / `_processResponseStream` / `_handleFunctionCall` に `ChatMode mode` パラメーターを追加
+- `_getModel`: `mode` に応じて `responseSchema`（雑談マスターモード）または `tools`（結社マスターモード）のどちらか一方のみを `GenerativeModel` に設定する
+- `_processResponseStream`: `plectrumSocietyMaster` の場合はプレーンテキストのレスポンスをチャンクごとにそのまま送出し、`chitChatMaster` の場合は従来通り JSON をバッファしてパースする
+- チャットセッションのキャッシュキーに `mode` を含め、同じ `systemPrompt` でもモードごとに別セッションとして扱う
+
+### 8. チャット画面のモードインジケーター・選択ダイアログ
+
+**配置**: `client/lib/ui/feature/home/home_screen.dart`, `client/lib/ui/component/chat_mode_selection_dialog.dart`
+
+**内容**:
+
+- チャット画面タイトル（カヴィヴァラの表示名）の下に、現在の回答モードを示す小さなラベルを表示
+- ラベルをタップすると `ChatModeSelectionDialog` を表示し、「自動選択」「プレクトラム結社マスターモード」「雑談マスターモード」を `RadioListTile` で選択できる
+- 選択を保存すると、自動選択の判定結果（`ResolvedChatMode`）をリセットし、次のメッセージから改めて判定できるようにする
+
+## データフロー
+
+### メッセージ送信時
+
+1. `ChatModeSelectionRepository` から現在の選択（自動選択または固定モード）を取得
+2. 固定モードの場合はそのモードを使用
+3. 自動選択の場合、`ResolvedChatMode` に判定済みの値があればそれを使用し、なければ `CavivaraKnowledgeBase.hasRelevantKnowledge` で文言を判定し、結果を `ResolvedChatMode` に保持
+4. 解決した `ChatMode` を `AiChatService.sendMessageStream` に渡す
+
+### チャットクリア時
+
+1. メッセージ一覧をクリア
+2. `ResolvedChatMode` をリセット（次回会話の初回メッセージで再判定できるようにする）
+3. `AiChatService.clearChatSession` で全 `ChatMode` 分のセッションキャッシュをクリア
+
+## 関連ドキュメント
+
+- [チャット吹き出しデザイン切り替え機能 概要設計書](switch-design.md) - モード選択ダイアログの実装パターンの参考
+- [AIからの返答後に次の質問候補をボタン表示する機能](../epic/ai-suggested-replies.md) - 雑談マスターモードで使用する返信サジェストの実装
+- [SharedPreferences 使用時の設計方法](../how-to-design-when-using-shared-preferences.md)


### PR DESCRIPTION
## 概要

プレクトラム結社の知識をFunction Callingで参照して回答する「プレクトラム結社マスターモード」と、返信サジェストを付与する「雑談マスターモード」を追加し、チャット画面のタイトル下のインジケーターから選択できるようにした。

- `ChatMode` / `ChatModeSelection` ドメインモデルと永続化用リポジトリを追加
- Gemini APIは Function Calling と レスポンススキーマ を同時に使用できないため、`AiChatService`でモードごとに切り替えるよう変更
- 自動選択モードでは、会話の最初のメッセージのみ `CavivaraKnowledgeBase` のキーワードで判定し、以降はその結果を維持する
- モード選択ダイアログ、UIインジケーター、関連テスト、設計ドキュメントを追加

Closes #476

⚠️ この環境では flutter/dart コマンドを実行できず、dart format/dart fix/build_runner/flutter test を実行できていません。マージ前にローカルで実行してください。

Generated with [Claude Code](https://claude.ai/code)