### PR TITLE
feat(client): App Check を Android でも有効化する

### DIFF
--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -111,15 +111,27 @@ FirebaseOptions? _getFirebaseOptions() {
 
 /// App Check をセットアップする
 ///
-/// App Check のプロバイダーは iOS 向けのみ用意しているため、iOS でのみ有効にする。
-/// iOS シミュレーターでは App Attest が利用できないため、デバッグプロバイダーを使用する。
-/// シミュレーターか否かは `isPhysicalDevice` で判定する。
+/// App Check のプロバイダーは iOS と Android 向けのみ用意しているため、
+/// それ以外のプラットフォームでは有効にしない。
 Future<void> _setupFirebaseAppCheck() async {
-  if (!Platform.isIOS) {
-    _logger.info('Firebase App Check: false');
+  if (Platform.isIOS) {
+    await _activateFirebaseAppCheckOnIOS();
     return;
   }
 
+  if (Platform.isAndroid) {
+    await _activateFirebaseAppCheckOnAndroid();
+    return;
+  }
+
+  _logger.info('Firebase App Check: false');
+}
+
+/// iOS 向けに App Check を有効にする
+///
+/// iOS シミュレーターでは App Attest が利用できないため、デバッグプロバイダーを使用する。
+/// シミュレーターか否かは `isPhysicalDevice` で判定する。
+Future<void> _activateFirebaseAppCheckOnIOS() async {
   final iosDeviceInfo = await DeviceInfoPlugin().iosInfo;
   final useDebugProvider = !iosDeviceInfo.isPhysicalDevice;
 
@@ -127,6 +139,27 @@ Future<void> _setupFirebaseAppCheck() async {
     providerApple: useDebugProvider
         ? const AppleDebugProvider()
         : const AppleAppAttestProvider(),
+  );
+
+  _logger.info(
+    'Firebase App Check: true (debug provider: $useDebugProvider)',
+  );
+}
+
+/// Android 向けに App Check を有効にする
+///
+/// Play Integrity は Google Play から配信されたアプリでのみ検証が通る。
+/// Google Play に配信するのはリリースビルドのみのため、
+/// それ以外のビルドではデバッグプロバイダーを使用する。
+/// デバッグプロバイダーの使用時は、起動時のログに出力されるデバッグトークンを
+/// Firebase コンソールに登録する必要がある。
+Future<void> _activateFirebaseAppCheckOnAndroid() async {
+  const useDebugProvider = !kReleaseMode;
+
+  await FirebaseAppCheck.instance.activate(
+    providerAndroid: useDebugProvider
+        ? const AndroidDebugProvider()
+        : const AndroidPlayIntegrityProvider(),
   );
 
   _logger.info(


### PR DESCRIPTION
## 概要

これまで iOS でのみ有効だった Firebase App Check を、Android でも有効にしました。

Android では Play Integrity プロバイダーを使用します。ただし Play Integrity は Google Play から配信されたアプリでのみ検証が通るため、リリースビルド以外（ローカルの debug / profile ビルド）ではデバッグプロバイダーを使用するようにしています。dev / prod とも fastlane から Google Play の internal トラックへ配信しているため、リリースビルドは Play Integrity で検証できます。

あわせて、プラットフォームごとの有効化処理を関数に分割しました。iOS 側の挙動（実機は App Attest、シミュレーターはデバッグプロバイダー）は変更していません。

### 別途必要なコンソール側の作業

コードの変更だけでは動作しないため、以下の対応が必要です。

1. **Play Integrity の登録**: dev / prod の各 Android アプリで App Check の Play Integrity を有効化する。あわせて Play App Signing の SHA-256 証明書フィンガープリント（Play Console の「アプリの署名」から取得）を Firebase プロジェクト設定に登録する。
2. **デバッグトークンの登録**: ローカルビルドの初回起動時に logcat へ出力されるデバッグトークンを、Firebase コンソールの App Check → アプリ → デバッグトークンの管理 に追加する。

なお、`firebase_app_check` プラグインの `android/build.gradle` が `firebase-appcheck-debug` と `firebase-appcheck-playintegrity` の両方をすでに含んでいるため、Gradle 側の変更は不要でした。

## 追加・修正ファイル

| ファイル | 内容 |
| --- | --- |
| `client/lib/main.dart` | `_setupFirebaseAppCheck()` から iOS / Android の有効化処理を `_activateFirebaseAppCheckOnIOS()` / `_activateFirebaseAppCheckOnAndroid()` に分割し、Android 向けに Play Integrity（リリースビルド以外はデバッグプロバイダー）を追加 |

## Related Issue

<!-- 該当する Issue 番号を記載してください。例: Closes #123 -->

## Screenshots & Demo

<!-- Android 実機／エミュレーターでの動作確認結果を記載してください。
     - デバッグプロバイダー使用時: 起動ログに `Firebase App Check: true (debug provider: true)` が出力されること
     - Firebase コンソールにデバッグトークンを登録後、Cloud Functions 等の呼び出しが成功すること -->

## レビューで見て欲しいポイント

<!-- レビュアーに特に確認してほしい点を記載してください。参考として、実装上の判断ポイントを挙げます。
     - デバッグプロバイダーの判定に `!kReleaseMode` を使っている点。iOS の `isPhysicalDevice` 判定とは基準が異なりますが、
       App Attest は実機かどうかで可否が決まるのに対し、Play Integrity は配信経路（Google Play 経由か）で決まるためです。
     - emulator flavor でも App Check を有効化する現状の挙動を維持している点。 -->