### PR TITLE
feat(settings): アカウントのログイン機能を隠す

### DIFF
--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -239,9 +239,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             children: [
               Text('現在、ゲストとしてアプリを利用しています。'),
               SizedBox(height: 8),
-              Text('アカウントでログインする機能は、今後実装する予定です。'),
+              Text(
+                'アプリをアンインストールすると、これまでのVP(ヴィヴァポイント)の履歴などが消えてしまいますので、ご注意ください。',
+              ),
               SizedBox(height: 8),
-              Text('アプリをアンインストールすると、これまでのヴィヴァポイントなどの履歴が消えてしまいますので、ご注意ください。'),
+              Text('アカウントを登録・ログインする機能は、今後追加される予定です。'),
             ],
           ),
           actions: [

--- a/client/lib/ui/feature/settings/settings_screen.dart
+++ b/client/lib/ui/feature/settings/settings_screen.dart
@@ -1,18 +1,14 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:house_worker/data/definition/app_definition.dart';
 import 'package:house_worker/data/definition/app_feature.dart';
-import 'package:house_worker/data/model/sign_in_result.dart';
 import 'package:house_worker/data/model/user_profile.dart';
 import 'package:house_worker/data/service/app_info_service.dart';
 import 'package:house_worker/data/service/auth_service.dart';
 import 'package:house_worker/data/service/firebase_installations_service.dart';
 import 'package:house_worker/data/service/remote_config_service.dart';
-import 'package:house_worker/ui/component/color.dart';
 import 'package:house_worker/ui/component/haptic_feedback_helper.dart';
 import 'package:house_worker/ui/component/supporter_title_extension.dart';
 import 'package:house_worker/ui/component/supporter_title_image.dart';
@@ -127,7 +123,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         leading = const Icon(Icons.person);
         titleText = 'ゲストユーザー';
         subtitle = null;
-        onTap = () => _showAnonymousUserInfoDialog(context);
+        onTap = () {
+          HapticFeedbackHelper.lightImpact();
+          _showAnonymousUserInfoDialog(context);
+        };
     }
 
     return ListTile(
@@ -224,130 +223,36 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
+  /// ゲストユーザーの説明ダイアログを表示する。
+  ///
+  /// アカウントでログインする機能は未提供のため、今後実装予定であることと、
+  /// アンインストールすると履歴が消える点を説明する。
   void _showAnonymousUserInfoDialog(BuildContext context) {
     showDialog<void>(
       context: context,
       builder: (context) {
-        final linkWithGoogleButton = TextButton.icon(
-          onPressed: _linkWithGoogle,
-          icon: const FaIcon(FontAwesomeIcons.google),
-          label: const Text('Googleと連携'),
-        );
-
-        final linkWithAppleButton = TextButton.icon(
-          onPressed: _linkWithApple,
-          icon: const FaIcon(FontAwesomeIcons.apple),
-          style: TextButton.styleFrom(
-            backgroundColor: signInWithAppleBackgroundColor(context),
-            foregroundColor: signInWithAppleForegroundColor(context),
-          ),
-          label: const Text('Appleと連携'),
-        );
-
-        final actions = <Widget>[linkWithGoogleButton];
-
-        if (Platform.isIOS) {
-          actions.add(linkWithAppleButton);
-        }
-
-        actions.add(
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('キャンセル'),
-          ),
-        );
-
         return AlertDialog(
-          title: const Text('アカウント連携'),
+          title: const Text('ゲストユーザーについて'),
           content: const Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text('現在、ゲストとしてアプリを利用しています。'),
               SizedBox(height: 8),
-              Text('アカウント連携をすると、以下の機能が利用できるようになります：'),
+              Text('アカウントでログインする機能は、今後実装する予定です。'),
               SizedBox(height: 8),
-              Text('• データのバックアップと復元'),
-              Text('• 複数のデバイスでの同期'),
-              Text('• 家族や友人との家事の共有'),
+              Text('アプリをアンインストールすると、これまでのヴィヴァポイントなどの履歴が消えてしまいますので、ご注意ください。'),
             ],
           ),
-          actions: actions,
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('閉じる'),
+            ),
+          ],
         );
       },
     );
-  }
-
-  Future<void> _linkWithGoogle() async {
-    Navigator.pop(context);
-
-    try {
-      await ref.read(authServiceProvider).linkWithGoogle();
-    } on LinkWithGoogleException catch (error) {
-      if (!mounted) {
-        return;
-      }
-
-      switch (error) {
-        case LinkWithGoogleExceptionCancelled():
-          return;
-        case LinkWithGoogleExceptionAlreadyInUse():
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('このGoogleアカウントは、既に利用されています。別のアカウントでお試しください。'),
-            ),
-          );
-          return;
-        case LinkWithGoogleExceptionUncategorized():
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('アカウント連携に失敗しました。しばらくしてから再度お試しください。')),
-          );
-      }
-    }
-
-    if (!mounted) {
-      return;
-    }
-
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('アカウントを連携しました')));
-  }
-
-  Future<void> _linkWithApple() async {
-    Navigator.pop(context);
-
-    try {
-      await ref.read(authServiceProvider).linkWithApple();
-    } on LinkWithAppleException catch (error) {
-      if (!mounted) {
-        return;
-      }
-
-      switch (error) {
-        case LinkWithAppleExceptionCancelled():
-          return;
-        case LinkWithAppleExceptionAlreadyInUse():
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('このApple IDは、既に利用されています。別のアカウントでお試しください。'),
-            ),
-          );
-          return;
-        case LinkWithAppleExceptionUncategorized():
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('アカウント連携に失敗しました。しばらくしてから再度お試しください。')),
-          );
-      }
-    }
-
-    if (!mounted) {
-      return;
-    }
-
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('アカウントを連携しました')));
   }
 }
 

--- a/client/test/ui/feature/settings/settings_screen_test.dart
+++ b/client/test/ui/feature/settings/settings_screen_test.dart
@@ -333,4 +333,111 @@ void main() {
       },
     );
   });
+
+  group('SettingsScreen - ゲストユーザーの説明機能', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      PackageInfo.setMockInitialValues(
+        appName: 'カヴィヴァラチャット',
+        packageName: 'com.example.app',
+        version: '1.0.0',
+        buildNumber: '1',
+        buildSignature: '',
+      );
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+      container = ProviderContainer(
+        overrides: [
+          currentUserProfileProvider.overrideWith((ref) {
+            return Stream.value(const UserProfileAnonymous(id: 'test-id'));
+          }),
+          currentPackagesProvider.overrideWith(
+            (ref) => Future.value(<ProductPackage>[]),
+          ),
+          firebaseInstallationIdProvider.overrideWith(
+            (ref) => Future.value('test-installation-id'),
+          ),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    testWidgets(
+      'ゲストユーザーのタイルをタップすると、'
+      '今後ログイン機能を実装する旨とアンインストール時の注意が表示されること',
+      (tester) async {
+        // Arrange
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: SettingsScreen(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Act - ゲストユーザーのタイルをタップ
+        await tester.tap(find.text('ゲストユーザー'));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('ゲストユーザーについて'), findsOneWidget);
+        expect(find.textContaining('今後実装する予定'), findsOneWidget);
+        expect(find.textContaining('アンインストール'), findsOneWidget);
+        expect(find.textContaining('ヴィヴァポイント'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'ゲストユーザーのタイルをタップしても、ログイン機能が表示されないこと',
+      (tester) async {
+        // Arrange
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: SettingsScreen(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Act - ゲストユーザーのタイルをタップ
+        await tester.tap(find.text('ゲストユーザー'));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Googleと連携'), findsNothing);
+        expect(find.text('Appleと連携'), findsNothing);
+      },
+    );
+
+    testWidgets('説明ダイアログは閉じるボタンで閉じられること', (tester) async {
+      // Arrange
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: SettingsScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('ゲストユーザー'));
+      await tester.pumpAndSettle();
+
+      // Act
+      await tester.tap(find.text('閉じる'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('ゲストユーザーについて'), findsNothing);
+    });
+  });
 }

--- a/client/test/ui/feature/settings/settings_screen_test.dart
+++ b/client/test/ui/feature/settings/settings_screen_test.dart
@@ -388,7 +388,7 @@ void main() {
 
         // Assert
         expect(find.text('ゲストユーザーについて'), findsOneWidget);
-        expect(find.textContaining('今後実装する予定'), findsOneWidget);
+        expect(find.textContaining('今後追加される予定'), findsOneWidget);
         expect(find.textContaining('アンインストール'), findsOneWidget);
         expect(find.textContaining('ヴィヴァポイント'), findsOneWidget);
       },


### PR DESCRIPTION
## 概要

closes #497

設定画面の「ゲストユーザー」タイルをタップした際に表示されていた、Google / Apple とのアカウント連携（ログイン）機能を削除しました。

代わりに、以下を説明するダイアログを表示するようにしています。

- 現在ゲストとしてアプリを利用していること
- アプリをアンインストールすると、これまでの VP(ヴィヴァポイント) の履歴などが消えてしまうこと
- アカウントを登録・ログインする機能は、今後追加される予定であること

あわせて、ダイアログを開く操作を他のタイルと揃えるため、タップ時に Haptic Feedback を追加しました。

なお、データ層の `AuthService.linkWithGoogle()` / `linkWithApple()`、`sign_in_result.dart` の `LinkWith*Exception`、`color.dart` の `signInWithApple*Color()` は未使用になりますが、今後ログイン機能を再度実装する想定のため残しています（ログイン画面の UI 削除時に `login_presenter` の `startWithGoogle()` / `startWithApple()` を残している前例に合わせています）。削除した方がよければ対応します。

## 追加・修正ファイル

| ファイル | 内容 |
| --- | --- |
| `client/lib/ui/feature/settings/settings_screen.dart` | ゲストユーザータイルのタップ時ダイアログから Google / Apple 連携ボタンと連携処理（`_linkWithGoogle()` / `_linkWithApple()`）を削除し、今後のログイン機能追加予定とアンインストール時の注意を説明するダイアログに変更。不要になった import と、タップ時の Haptic Feedback 追加 |
| `client/test/ui/feature/settings/settings_screen_test.dart` | ゲストユーザーの説明機能のテストを追加（説明文言が表示されること、連携ボタンが表示されないこと、閉じるボタンでダイアログを閉じられること） |

## Related Issue

Closes #497

## Screenshots & Demo

<!-- 実機／シミュレーターでの表示確認結果を記載してください。
     - 設定画面 →「ゲストユーザー」タップ →「ゲストユーザーについて」ダイアログの表示
     - Google / Apple の連携ボタンが表示されないこと -->

## レビューで見て欲しいポイント

<!-- レビュアーに特に確認してほしい点を記載してください。参考として、実装上の判断ポイントを挙げます。
     - ダイアログの文言（説明の順序・表現）が意図どおりか。
     - データ層の連携処理（`AuthService.linkWithGoogle()` / `linkWithApple()` など）を残すか削除するか。 -->

## 補足

サンドボックス環境の制約により `flutter test` を実行できていません（テストハーネスのローカルソケット bind が拒否されるため）。`flutter analyze --fatal-infos` は警告ゼロ、`dart format` / `dart fix --apply` は適用済みです。テストの実行結果の確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
